### PR TITLE
Set dependabot reviewer to atlas

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
       time: "04:00"
     open-pull-requests-limit: 10
     reviewers:
-      - giantswarm/team-biscuit
+      - giantswarm/team-atlas
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
@@ -19,7 +19,7 @@ updates:
       time: "04:00"
     open-pull-requests-limit: 10
     reviewers:
-      - giantswarm/team-biscuit
+      - giantswarm/team-atlas
     ignore:
       - dependency-name: zricethezav/gitleaks-action
   - package-ecosystem: gomod

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,7 +29,7 @@ updates:
       time: "04:00"
     open-pull-requests-limit: 10
     reviewers:
-      - giantswarm/team-biscuit
+      - giantswarm/team-atlas
     ignore:
       - dependency-name: k8s.io/*
         versions:


### PR DESCRIPTION
To prevent team biscuit being pinged for dependency updates