### PR TITLE
Respect 'giantswarm.io/keep' annotation on initial cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Respect `giantswarm.io/keep: true` annotations on Silences when performing the initial cleanup
+
 ## [0.2.2] - 2021-08-13
 
 ### Changed

--- a/cmd/sync/runner.go
+++ b/cmd/sync/runner.go
@@ -13,6 +13,7 @@ import (
 	monitoringv1alpha1 "github.com/giantswarm/apiextensions/v3/pkg/apis/monitoring/v1alpha1"
 	monitoringv1alpha1client "github.com/giantswarm/apiextensions/v3/pkg/clientset/versioned/typed/monitoring/v1alpha1"
 	"github.com/giantswarm/k8sclient/v4/pkg/k8srestconfig"
+	"github.com/giantswarm/k8smetadata/pkg/annotation"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/cobra"
@@ -143,7 +144,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 
 	// delete expired silences
 	for _, currentSilence := range currentSilences.Items {
-		if !silenceInList(currentSilence, filteredSilences) {
+		if !silenceInList(currentSilence, filteredSilences) && !hasKeepAnnotation(currentSilence) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting expired silence CR %#q", currentSilence.Name))
 
 			err = k8sClient.Silences().Delete(ctx, currentSilence.Name, metav1.DeleteOptions{})
@@ -197,4 +198,9 @@ func silenceInList(silence monitoringv1alpha1.Silence, silences []monitoringv1al
 	}
 
 	return false
+}
+
+func hasKeepAnnotation(silence monitoringv1alpha1.Silence) bool {
+	keep, ok := silence.ObjectMeta.Annotations[annotation.Keep]
+	return ok && keep == "true"
 }

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/giantswarm/apiextensions/v3 v3.35.0
 	github.com/giantswarm/exporterkit v0.2.1
 	github.com/giantswarm/k8sclient/v4 v4.1.0
+	github.com/giantswarm/k8smetadata v0.5.0
 	github.com/giantswarm/microendpoint v0.2.0
 	github.com/giantswarm/microerror v0.3.0
 	github.com/giantswarm/microkit v0.2.2

--- a/go.sum
+++ b/go.sum
@@ -213,6 +213,8 @@ github.com/giantswarm/exporterkit v0.2.1/go.mod h1:LkZNK+2qTcbHspbizA6JBBXpQW99u
 github.com/giantswarm/k8sclient/v4 v4.0.0/go.mod h1:jTwQ8q0YbJJu3ZxbjoI6hkXeuvKm15xyI/c+zwxnUH0=
 github.com/giantswarm/k8sclient/v4 v4.1.0 h1:kquaq+qAQ/x4voocbOrn3WfskojANpvg0B7srhL3YSM=
 github.com/giantswarm/k8sclient/v4 v4.1.0/go.mod h1:jTwQ8q0YbJJu3ZxbjoI6hkXeuvKm15xyI/c+zwxnUH0=
+github.com/giantswarm/k8smetadata v0.5.0 h1:1AJBUi6bqxeM5ZzlDDHqq+f36Nv+Qy7ioGozO9G20Aw=
+github.com/giantswarm/k8smetadata v0.5.0/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
 github.com/giantswarm/microendpoint v0.2.0 h1:xCAqAVRjTw/4ifEuBeNavALdbQsLk6+k/ukzdy0GWZE=
 github.com/giantswarm/microendpoint v0.2.0/go.mod h1:SSkSp4Q4iSW7vwkil+/E3IXy9Q8To8vXmT5VCg24RDg=
 github.com/giantswarm/microerror v0.2.0/go.mod h1:1YtJq/m7Vlq1Y6NP7B+SODOKCGlG7e5wctV2OoE9n34=


### PR DESCRIPTION
Doesn't remove an existing Silence CR if it has the `giantswarm.io/keep: "true"` annotation added.

## Checklist

- [x] Update changelog in CHANGELOG.md.
