### PR TITLE
Label selector

### DIFF
--- a/api/v1alpha1/silence_types.go
+++ b/api/v1alpha1/silence_types.go
@@ -22,8 +22,8 @@ type Silence struct {
 
 // +k8s:openapi-gen=true
 type SilenceSpec struct {
-	TargetTags []TargetTag `json:"targetTags"`
-	Matchers   []Matcher   `json:"matchers"`
+	TargetTags *metav1.LabelSelector `json:"targetTags"`
+	Matchers   []Matcher             `json:"matchers"`
 
 	// Owner is GitHub username of a person who created and/or owns the silence.
 	Owner *string `json:"owner,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -22,6 +22,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -103,8 +104,8 @@ func (in *SilenceSpec) DeepCopyInto(out *SilenceSpec) {
 	*out = *in
 	if in.TargetTags != nil {
 		in, out := &in.TargetTags, &out.TargetTags
-		*out = make([]TargetTag, len(*in))
-		copy(*out, *in)
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Matchers != nil {
 		in, out := &in.Matchers, &out.Matchers

--- a/cmd/sync/flag.go
+++ b/cmd/sync/flag.go
@@ -23,19 +23,15 @@ type flag struct {
 
 func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringSliceVar(&f.Dirs, flagDir, []string{}, "Directory to look for yaml with silence CRs.")
-	cmd.Flags().StringSliceVar(&f.Tags, flagTag, []string{}, "Tags, used for to match current environment.")
+	cmd.Flags().StringSliceVar(&f.Tags, flagTag, []string{}, "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2). Matching objects must satisfy all of the specified label constraints.")
 
 	cmd.Flags().BoolVar(&f.KubernetesInCluster, flagKubernetesInCluster, false, "Whether to use the in-cluster config to authenticate with Kubernetes.")
 	cmd.Flags().StringVar(&f.KubernetesKubeconfig, flagKubernetesKubeconfig, "", "KubeConfig used to connect to Kubernetes.")
-
 }
 
 func (f *flag) Validate() error {
 	if len(f.Dirs) == 0 {
 		return microerror.Maskf(invalidFlagError, "--%s must not be empty", flagDir)
-	}
-	if len(f.Tags) == 0 {
-		return microerror.Maskf(invalidFlagError, "--%s must not be empty", flagTag)
 	}
 
 	if !f.KubernetesInCluster && f.KubernetesKubeconfig == "" {

--- a/cmd/sync/runner.go
+++ b/cmd/sync/runner.go
@@ -66,19 +66,8 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		}
 	}
 
-	// find yamls with CRs
-	var silenceFiles []string
-	{
-		for _, dir := range r.flag.Dirs {
-			files, err := findYamls(dir)
-			if err != nil {
-				return microerror.Mask(err)
-			}
-			silenceFiles = append(silenceFiles, files...)
-		}
-	}
-
-	tags := make(map[string]string)
+	// Load silence filtering tags.
+	var tags = make(map[string]string)
 	{
 		for _, tag := range r.flag.Tags {
 			tagObj := strings.SplitN(tag, "=", 2)
@@ -89,6 +78,18 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 			}
 
 			tags[tagName] = tagValue
+		}
+	}
+
+	// find yamls with CRs
+	var silenceFiles []string
+	{
+		for _, dir := range r.flag.Dirs {
+			files, err := findYamls(dir)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+			silenceFiles = append(silenceFiles, files...)
 		}
 	}
 

--- a/cmd/sync/runner.go
+++ b/cmd/sync/runner.go
@@ -58,15 +58,12 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		ctrlClient, err = getCtrlClient(c)
 	}
 
+	var currentSilences monitoringv1alpha1.SilenceList
 	{
+		err = ctrlClient.List(ctx, &currentSilences)
 		if err != nil {
 			return microerror.Mask(err)
 		}
-
-	var currentSilences monitoringv1alpha1.SilenceList
-	err = ctrlClient.List(ctx, &currentSilences)
-	if err != nil {
-		return microerror.Mask(err)
 	}
 
 	// find yamls with CRs

--- a/cmd/sync/runner_test.go
+++ b/cmd/sync/runner_test.go
@@ -183,12 +183,16 @@ func Test_isValidSilence(t *testing.T) {
 				},
 			}
 
-			tags := runner.loadTags()
+			tags, err := runner.loadTags()
+			if err != nil {
+				t.Error(err)
+			}
 
 			isValid, err := runner.isValidSilence(context.Background(), test.Silence, tags)
 			if err != nil {
 				t.Error(err)
 			}
+
 			if isValid != test.IsValid {
 				t.Errorf("failure: expected isValid=%t, got isValid=%t with silence.spec.targetTags %v matched with tags %v\n", test.IsValid, isValid, test.Silence.Spec.TargetTags, test.Tags)
 			}

--- a/cmd/sync/runner_test.go
+++ b/cmd/sync/runner_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/giantswarm/micrologger"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/giantswarm/silence-operator/api/v1alpha1"
 )
 
@@ -34,10 +36,9 @@ func Test_isValidSilence(t *testing.T) {
 			"silence with tags against same tags is valid",
 			v1alpha1.Silence{
 				Spec: v1alpha1.SilenceSpec{
-					TargetTags: []v1alpha1.TargetTag{
-						{
-							Name:  "foo",
-							Value: "bar",
+					TargetTags: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"foo": "bar",
 						},
 					},
 				},
@@ -51,10 +52,9 @@ func Test_isValidSilence(t *testing.T) {
 			"silence with tags against different tags is invalid",
 			v1alpha1.Silence{
 				Spec: v1alpha1.SilenceSpec{
-					TargetTags: []v1alpha1.TargetTag{
-						{
-							Name:  "foo",
-							Value: "bar",
+					TargetTags: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"foo": "bar",
 						},
 					},
 				},
@@ -68,10 +68,9 @@ func Test_isValidSilence(t *testing.T) {
 			"silence with tags against no tags is invalid",
 			v1alpha1.Silence{
 				Spec: v1alpha1.SilenceSpec{
-					TargetTags: []v1alpha1.TargetTag{
-						{
-							Name:  "foo",
-							Value: "bar",
+					TargetTags: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"foo": "bar",
 						},
 					},
 				},
@@ -83,14 +82,10 @@ func Test_isValidSilence(t *testing.T) {
 			"silence with multiple tags against same tags is valid",
 			v1alpha1.Silence{
 				Spec: v1alpha1.SilenceSpec{
-					TargetTags: []v1alpha1.TargetTag{
-						{
-							Name:  "foo",
-							Value: "bar",
-						},
-						{
-							Name:  "one",
-							Value: "two",
+					TargetTags: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"foo": "bar",
+							"one": "two",
 						},
 					},
 				},
@@ -105,14 +100,10 @@ func Test_isValidSilence(t *testing.T) {
 			"silence with multiple unordered tags against same tags is valid",
 			v1alpha1.Silence{
 				Spec: v1alpha1.SilenceSpec{
-					TargetTags: []v1alpha1.TargetTag{
-						{
-							Name:  "one",
-							Value: "two",
-						},
-						{
-							Name:  "foo",
-							Value: "bar",
+					TargetTags: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"one": "two",
+							"foo": "bar",
 						},
 					},
 				},
@@ -127,14 +118,10 @@ func Test_isValidSilence(t *testing.T) {
 			"silence with multiple tags against unordered same tags is valid",
 			v1alpha1.Silence{
 				Spec: v1alpha1.SilenceSpec{
-					TargetTags: []v1alpha1.TargetTag{
-						{
-							Name:  "foo",
-							Value: "bar",
-						},
-						{
-							Name:  "one",
-							Value: "two",
+					TargetTags: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"foo": "bar",
+							"one": "two",
 						},
 					},
 				},
@@ -149,14 +136,10 @@ func Test_isValidSilence(t *testing.T) {
 			"silence with multiple tags against one tag is invalid",
 			v1alpha1.Silence{
 				Spec: v1alpha1.SilenceSpec{
-					TargetTags: []v1alpha1.TargetTag{
-						{
-							Name:  "foo",
-							Value: "bar",
-						},
-						{
-							Name:  "one",
-							Value: "two",
+					TargetTags: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"foo": "bar",
+							"one": "two",
 						},
 					},
 				},
@@ -170,10 +153,9 @@ func Test_isValidSilence(t *testing.T) {
 			"silence with one tag against multiple tags is valid",
 			v1alpha1.Silence{
 				Spec: v1alpha1.SilenceSpec{
-					TargetTags: []v1alpha1.TargetTag{
-						{
-							Name:  "one",
-							Value: "two",
+					TargetTags: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"one": "two",
 						},
 					},
 				},

--- a/cmd/sync/runner_test.go
+++ b/cmd/sync/runner_test.go
@@ -166,23 +166,6 @@ func Test_isValidSilence(t *testing.T) {
 			},
 			true,
 		},
-		{
-			"silence weird",
-			v1alpha1.Silence{
-				Spec: v1alpha1.SilenceSpec{
-					TargetTags: []v1alpha1.TargetTag{
-						{
-							Name:  "one",
-							Value: "",
-						},
-					},
-				},
-			},
-			[]string{
-				"foo=bar",
-			},
-			true,
-		},
 	}
 
 	logger, err := micrologger.New(micrologger.Config{IOWriter: io.Discard})

--- a/cmd/sync/runner_test.go
+++ b/cmd/sync/runner_test.go
@@ -1,0 +1,232 @@
+package sync
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/silence-operator/api/v1alpha1"
+)
+
+func Test_isValidSilence(t *testing.T) {
+	tests := []struct {
+		Name    string
+		Silence v1alpha1.Silence
+		Tags    []string
+		IsValid bool
+	}{
+		{
+			"empty silence against no tags is valid",
+			v1alpha1.Silence{},
+			nil,
+			true,
+		},
+		{
+			"empty silence against tags is valid",
+			v1alpha1.Silence{},
+			[]string{
+				"foo=bar",
+			},
+			true,
+		},
+		{
+			"silence with tags against same tags is valid",
+			v1alpha1.Silence{
+				Spec: v1alpha1.SilenceSpec{
+					TargetTags: []v1alpha1.TargetTag{
+						{
+							Name:  "foo",
+							Value: "bar",
+						},
+					},
+				},
+			},
+			[]string{
+				"foo=bar",
+			},
+			true,
+		},
+		{
+			"silence with tags against different tags is invalid",
+			v1alpha1.Silence{
+				Spec: v1alpha1.SilenceSpec{
+					TargetTags: []v1alpha1.TargetTag{
+						{
+							Name:  "foo",
+							Value: "bar",
+						},
+					},
+				},
+			},
+			[]string{
+				"one=two",
+			},
+			false,
+		},
+		{
+			"silence with tags against no tags is invalid",
+			v1alpha1.Silence{
+				Spec: v1alpha1.SilenceSpec{
+					TargetTags: []v1alpha1.TargetTag{
+						{
+							Name:  "foo",
+							Value: "bar",
+						},
+					},
+				},
+			},
+			nil,
+			false,
+		},
+		{
+			"silence with multiple tags against same tags is valid",
+			v1alpha1.Silence{
+				Spec: v1alpha1.SilenceSpec{
+					TargetTags: []v1alpha1.TargetTag{
+						{
+							Name:  "foo",
+							Value: "bar",
+						},
+						{
+							Name:  "one",
+							Value: "two",
+						},
+					},
+				},
+			},
+			[]string{
+				"foo=bar",
+				"one=two",
+			},
+			true,
+		},
+		{
+			"silence with multiple unordered tags against same tags is valid",
+			v1alpha1.Silence{
+				Spec: v1alpha1.SilenceSpec{
+					TargetTags: []v1alpha1.TargetTag{
+						{
+							Name:  "one",
+							Value: "two",
+						},
+						{
+							Name:  "foo",
+							Value: "bar",
+						},
+					},
+				},
+			},
+			[]string{
+				"foo=bar",
+				"one=two",
+			},
+			true,
+		},
+		{
+			"silence with multiple tags against unordered same tags is valid",
+			v1alpha1.Silence{
+				Spec: v1alpha1.SilenceSpec{
+					TargetTags: []v1alpha1.TargetTag{
+						{
+							Name:  "foo",
+							Value: "bar",
+						},
+						{
+							Name:  "one",
+							Value: "two",
+						},
+					},
+				},
+			},
+			[]string{
+				"one=two",
+				"foo=bar",
+			},
+			true,
+		},
+		{
+			"silence with multiple tags against one tag is invalid",
+			v1alpha1.Silence{
+				Spec: v1alpha1.SilenceSpec{
+					TargetTags: []v1alpha1.TargetTag{
+						{
+							Name:  "foo",
+							Value: "bar",
+						},
+						{
+							Name:  "one",
+							Value: "two",
+						},
+					},
+				},
+			},
+			[]string{
+				"one=two",
+			},
+			false,
+		},
+		{
+			"silence with one tag against multiple tags is valid",
+			v1alpha1.Silence{
+				Spec: v1alpha1.SilenceSpec{
+					TargetTags: []v1alpha1.TargetTag{
+						{
+							Name:  "one",
+							Value: "two",
+						},
+					},
+				},
+			},
+			[]string{
+				"foo=bar",
+				"one=two",
+			},
+			true,
+		},
+		{
+			"silence weird",
+			v1alpha1.Silence{
+				Spec: v1alpha1.SilenceSpec{
+					TargetTags: []v1alpha1.TargetTag{
+						{
+							Name:  "one",
+							Value: "",
+						},
+					},
+				},
+			},
+			[]string{
+				"foo=bar",
+			},
+			true,
+		},
+	}
+
+	logger, err := micrologger.New(micrologger.Config{IOWriter: io.Discard})
+	//logger, err := micrologger.New(micrologger.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			runner := runner{
+				logger: logger,
+				flag: &flag{
+					Tags: test.Tags,
+				},
+			}
+
+			tags := runner.loadTags()
+
+			isValid, err := runner.isValidSilence(context.Background(), test.Silence, tags)
+			if err != nil {
+				t.Error(err)
+			}
+			if isValid != test.IsValid {
+				t.Errorf("failure: expected isValid=%t, got isValid=%t with silence.spec.targetTags %v matched with tags %v\n", test.IsValid, isValid, test.Silence.Spec.TargetTags, test.Tags)
+			}
+		})
+	}
+}

--- a/config/crd/monitoring.giantswarm.io_silences.yaml
+++ b/config/crd/monitoring.giantswarm.io_silences.yaml
@@ -65,17 +65,52 @@ spec:
                   problem.
                 type: string
               targetTags:
-                items:
-                  properties:
-                    name:
+                description: A label selector is a label query over a set of resources.
+                  The result of matchLabels and matchExpressions are ANDed. An empty
+                  label selector matches all objects. A null label selector matches
+                  no objects.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
                       type: string
-                    value:
-                      type: string
-                  required:
-                  - name
-                  - value
-                  type: object
-                type: array
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
             required:
             - matchers
             - targetTags


### PR DESCRIPTION
Moving from custom tag filtering to label selector

Basically moving from `--tags=installation=test` to `--selector=installation=test`, where `--selector` is the standard kubernetes label selector from https://pkg.go.dev/k8s.io/apimachinery/pkg/labels#Selector, allowing for any label selector we are used to.

### Before

```
$ ./silence-operator sync --dir ./test --kubernetes.kubeconfig "$(cat ~/.kube/config)" --tag installation=gauss
{"caller":"github.com/giantswarm/k8sclient/v6/pkg/k8srestconfig/rest_config.go:131","level":"debug","message":"creating REST config from kubeconfig","time":"2022-04-20T16:16:58.443043+00:00"}
{"caller":"github.com/giantswarm/k8sclient/v6/pkg/k8srestconfig/rest_config.go:139","level":"debug","message":"created REST config from kubeconfig","time":"2022-04-20T16:16:58.444199+00:00"}
{"caller":"github.com/giantswarm/silence-operator/cmd/sync/runner.go:225","level":"debug","message":"silence `gauss-wrongtarget` does not match environment by `installation` key [regexp: `wrong`, value: `gauss`]","time":"2022-04-20T16:16:59.824704+00:00"}
{"caller":"github.com/giantswarm/silence-operator/cmd/sync/runner.go:117","level":"debug","message":"creating desired silence CR `gauss-goodtarget`","time":"2022-04-20T16:16:59.824758+00:00"}
{"caller":"github.com/giantswarm/silence-operator/cmd/sync/runner.go:124","level":"debug","message":"desired silence CR `gauss-goodtarget` has been created","time":"2022-04-20T16:16:59.947656+00:00"}
```

### After

```
$ ./silence-operator sync --dir ./test --kubernetes.kubeconfig "$(cat ~/.kube/config)" --selector=installation=gauss
{"caller":"github.com/giantswarm/k8sclient/v6/pkg/k8srestconfig/rest_config.go:131","level":"debug","message":"creating REST config from kubeconfig","time":"2022-04-20T16:37:23.790887+00:00"}
{"caller":"github.com/giantswarm/k8sclient/v6/pkg/k8srestconfig/rest_config.go:139","level":"debug","message":"created REST config from kubeconfig","time":"2022-04-20T16:37:23.792208+00:00"}
{"caller":"github.com/giantswarm/silence-operator/cmd/sync/runner.go:196","level":"debug","message":"silence `gauss-wrongtarget` with labels `installation=wrong` does not match `installation=gauss` selector","time":"2022-04-20T16:37:24.920613+00:00"}
{"caller":"github.com/giantswarm/silence-operator/cmd/sync/runner.go:100","level":"debug","message":"creating desired silence CR `gauss-goodtarget`","time":"2022-04-20T16:37:25.040498+00:00"}
{"caller":"github.com/giantswarm/silence-operator/cmd/sync/runner.go:107","level":"debug","message":"desired silence CR `gauss-goodtarget` has been created","time":"2022-04-20T16:37:25.152684+00:00"}
```