### PR TITLE
Set startingDeadlineSeconds to ensure the job gets schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Dependencies updates, solves some of Nancy security alerts
+- Set `startingDeadlineSeconds` to 240 seconds to ensure it is scheduled and to avoid `FailedNeedsStart` events. 
 
 ## [0.6.1] - 2022-04-12
 

--- a/helm/silence-operator/templates/cronjob.yaml
+++ b/helm/silence-operator/templates/cronjob.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
 spec:
+  startingDeadlineSeconds: 240
   concurrencyPolicy: Allow
   jobTemplate:
     metadata:
@@ -14,6 +15,7 @@ spec:
       annotations:
         releaseRevision: {{ .Release.Revision | quote }}
     spec:
+      
       template:
         metadata:
           labels:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/22350

Let's set the deadline to 240s for now as it fixed but issue and reassess if we get paged again

## Checklist

- [x] Update changelog in CHANGELOG.md.
