### PR TITLE
fix: reconcile api comparison fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ TODO
 /silence-operator
 /silence-operator-v*-*-linux-*
 /silence-operator-v*-*-darwin-*
+/silence-operator-v*-*-amd64-*
 !vendor/**


### PR DESCRIPTION
Fixes the reconcile logic that was comparing two different structs, leading to a lot of CR updates that shouldn't happen:

![image](https://user-images.githubusercontent.com/19607336/192242959-ff7a00e9-57b2-43fb-b737-9fa55ffd2a60.png)
