### PR TITLE
Add IssueURL field to Silence CRD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add IssueURL field to Silence CRD.
+
 ### Changed
 
 - Bump github.com/spf13/cobra from 1.4.0 to 1.5.0.
@@ -17,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump github.com/giantswarm/k8smetadata from 0.11.1 to 0.12.0
 - Bump sigs.k8s.io/controller-runtime from 0.12.3 to 0.13.0
 - Reconcile API if Silence CR gets updated
+- Deprecate PostmortemURL field in favour of IssueURL.
+- Make Silence Owner field a string instead of string pointer.
 
 ## [0.7.0] - 2022-06-13
 

--- a/api/v1alpha1/silence_types.go
+++ b/api/v1alpha1/silence_types.go
@@ -29,11 +29,11 @@ type SilenceSpec struct {
 	Owner string `json:"owner,omitempty"`
 
 	// PostmortemURL is a link to a document describing the problem.
-    // Deprecated: Use IssueURL instead.
+	// Deprecated: Use IssueURL instead.
 	PostmortemURL *string `json:"postmortem_url,omitempty"`
 
-    // IssueURL is a link to a GitHub issue describing the problem.
-    IssueURL string `json:"issue_url,omitempty"`
+	// IssueURL is a link to a GitHub issue describing the problem.
+	IssueURL string `json:"issue_url,omitempty"`
 }
 
 type TargetTag struct {

--- a/api/v1alpha1/silence_types.go
+++ b/api/v1alpha1/silence_types.go
@@ -26,10 +26,14 @@ type SilenceSpec struct {
 	Matchers   []Matcher   `json:"matchers"`
 
 	// Owner is GitHub username of a person who created and/or owns the silence.
-	Owner *string `json:"owner,omitempty"`
+	Owner string `json:"owner,omitempty"`
 
 	// PostmortemURL is a link to a document describing the problem.
+    // Deprecated: Use IssueURL instead.
 	PostmortemURL *string `json:"postmortem_url,omitempty"`
+
+    // IssueURL is a link to a GitHub issue describing the problem.
+    IssueURL string `json:"issue_url,omitempty"`
 }
 
 type TargetTag struct {

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -111,11 +111,6 @@ func (in *SilenceSpec) DeepCopyInto(out *SilenceSpec) {
 		*out = make([]Matcher, len(*in))
 		copy(*out, *in)
 	}
-	if in.Owner != nil {
-		in, out := &in.Owner, &out.Owner
-		*out = new(string)
-		**out = **in
-	}
 	if in.PostmortemURL != nil {
 		in, out := &in.PostmortemURL, &out.PostmortemURL
 		*out = new(string)

--- a/config/crd/monitoring.giantswarm.io_silences.yaml
+++ b/config/crd/monitoring.giantswarm.io_silences.yaml
@@ -39,6 +39,9 @@ spec:
             type: object
           spec:
             properties:
+              issue_url:
+                description: IssueURL is a link to a GitHub issue describing the problem.
+                type: string
               matchers:
                 items:
                   properties:
@@ -61,8 +64,8 @@ spec:
                   owns the silence.
                 type: string
               postmortem_url:
-                description: PostmortemURL is a link to a document describing the
-                  problem.
+                description: 'PostmortemURL is a link to a document describing the
+                  problem. Deprecated: Use IssueURL instead.'
                 type: string
               targetTags:
                 items:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/20660

- Add IssueURL field to Silence CRD
- Deprecate PostmortemURL field in favour of IssueURL.
- Make Silence Owner field a string instead of string pointer.

## Checklist

- [x] Update changelog in CHANGELOG.md.
