### PR TITLE
Improve helm configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add IssueURL field to Silence CRD.
+- Make Helm chart CronJob optional
 
 ### Changed
 
@@ -43,7 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Dependencies updates, solves some of Nancy security alerts
-- Set `startingDeadlineSeconds` to 240 seconds to ensure it is scheduled and to avoid `FailedNeedsStart` events. 
+- Set `startingDeadlineSeconds` to 240 seconds to ensure it is scheduled and to avoid `FailedNeedsStart` events.
 
 ## [0.6.1] - 2022-04-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add IssueURL field to Silence CRD.
 - Make Helm chart CronJob optional
+- Make Helm chart AlertManager address configurable
 
 ### Changed
 

--- a/helm/silence-operator/templates/configmap.yaml
+++ b/helm/silence-operator/templates/configmap.yaml
@@ -15,7 +15,7 @@ data:
         address: 'http://0.0.0.0:8000'
     service:
       alertmanager:
-        address: http://alertmanager-operated.monitoring.svc:9093
+        address: {{ .Values.alertmanagerAddress }}
       kubernetes:
         address: ''
         inCluster: true

--- a/helm/silence-operator/templates/cronjob.yaml
+++ b/helm/silence-operator/templates/cronjob.yaml
@@ -68,4 +68,4 @@ spec:
   schedule: "*/5 * * * *"
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
-  {{- end }}
+{{- end }}

--- a/helm/silence-operator/templates/cronjob.yaml
+++ b/helm/silence-operator/templates/cronjob.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.sync.enabled -}}
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
@@ -67,3 +68,4 @@ spec:
   schedule: "*/5 * * * *"
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
+  {{- end }}

--- a/helm/silence-operator/values.yaml
+++ b/helm/silence-operator/values.yaml
@@ -11,6 +11,7 @@ project:
   commit: "[[ .SHA ]]"
 
 sync:
+  enabled: true
   repository: github.com/giantswarm/silences
   github:
     token: ""

--- a/helm/silence-operator/values.yaml
+++ b/helm/silence-operator/values.yaml
@@ -2,7 +2,7 @@ image:
   name: "giantswarm/silence-operator"
   tag: "[[ .Version ]]"
 
-alertmanagerAddress: http://alertmanager-oeprated.monitoring.svc:9093
+alertmanagerAddress: http://alertmanager-operated.monitoring.svc:9093
 
 pod:
   user:

--- a/helm/silence-operator/values.yaml
+++ b/helm/silence-operator/values.yaml
@@ -1,11 +1,15 @@
 image:
   name: "giantswarm/silence-operator"
   tag: "[[ .Version ]]"
+
+alertmanagerAddress: http://alertmanager-oeprated.monitoring.svc:9093
+
 pod:
   user:
     id: 1000
   group:
     id: 1000
+
 project:
   branch: "[[ .Branch ]]"
   commit: "[[ .SHA ]]"


### PR DESCRIPTION
This allows the cronjob to be disabled (for example to allow CR to be deployed in another manner) and makes the alertmanager address configurable. The defaults for both are to retain the existing behaviour

## Checklist

- [x] Update changelog in CHANGELOG.md.
