### PR TITLE
Use securityContext values in CronJob

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -1,9 +1,9 @@
 # pkg:golang/github.com/hashicorp/consul/api@v1.18.0
-CVE-2022-29153 until=2023-07-01
+CVE-2022-29153 until=2023-08-01
 
 # pkg:golang/k8s.io/apiserver@v0.26.0
-CVE-2020-8561 until=2023-07-01
+CVE-2020-8561 until=2023-08-01
 
 # pkg:golang/github.com/gin-gonic/gin@v1.8.1
-CVE-2023-26125 until=2023-07-01
-CVE-2023-29401 until=2023-07-01
+CVE-2023-26125 until=2023-08-01
+CVE-2023-29401 until=2023-08-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add Kyverno Policy Exceptions.
+- Use `securityContext` values inside CronJob template.
 
 ## [0.9.1] - 2023-05-25
 

--- a/helm/silence-operator/templates/cronjob.yaml
+++ b/helm/silence-operator/templates/cronjob.yaml
@@ -56,7 +56,7 @@ spec:
               name: silences
               readOnly: true
           dnsPolicy: ClusterFirst
-          restartPolicy: OnFailure  
+          restartPolicy: OnFailure
           schedulerName: default-scheduler
           serviceAccountName: {{ include "resource.default.name"  . }}
           securityContext:

--- a/helm/silence-operator/templates/cronjob.yaml
+++ b/helm/silence-operator/templates/cronjob.yaml
@@ -62,7 +62,7 @@ spec:
           securityContext:
             runAsUser: {{ .Values.pod.user.id }}
             runAsGroup: {{ .Values.pod.group.id }}
-            {{- with .Values.securityContext }}
+            {{- with .Values.podSecurityContext }}
               {{- . | toYaml | nindent 12 }}
             {{- end }}
           volumes:

--- a/helm/silence-operator/templates/cronjob.yaml
+++ b/helm/silence-operator/templates/cronjob.yaml
@@ -56,12 +56,15 @@ spec:
               name: silences
               readOnly: true
           dnsPolicy: ClusterFirst
-          restartPolicy: OnFailure
+          restartPolicy: OnFailure  
           schedulerName: default-scheduler
           serviceAccountName: {{ include "resource.default.name"  . }}
           securityContext:
             runAsUser: {{ .Values.pod.user.id }}
             runAsGroup: {{ .Values.pod.group.id }}
+            {{- with .Values.securityContext }}
+              {{- . | toYaml | nindent 12 }}
+            {{- end }}
           volumes:
           - name: silences
             emptyDir: {}


### PR DESCRIPTION
Fixes issues while trying to use an unrestricted SeccompProfile. The values were already there but were not used by the CronJob, this PRs adds them.