### PR TITLE
Fix silence controller error management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix ignored error on accessing the silences.
+
 ## [0.10.0] - 2023-06-27
 
 ### Added

--- a/service/controller/resource/silence/create.go
+++ b/service/controller/resource/silence/create.go
@@ -58,6 +58,9 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	var existingSilence *alertmanager.Silence
 	existingSilence, err = r.amClient.GetSilenceByComment(key.SilenceComment(silence))
 	notFound := alertmanager.IsNotFound(err)
+	if !notFound && err != nil {
+		return microerror.Mask(err)
+	}
 	if notFound {
 		if newSilence.EndsAt.After(now) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "creating silence")


### PR DESCRIPTION
Fix incorrect error management that will now be transformed into a silence-operator reconciliation error that will page us instead of panicking

Towards https://github.com/giantswarm/giantswarm/issues/27466

## Checklist

- [x] Update changelog in CHANGELOG.md.
