### PR TITLE
Add Alertmanager authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added option to use Service Account token for Alertmanager authentication.
+
 ## [0.11.2] - 2023-12-06
 
 ### Changed

--- a/flag/service/alertmanager/alertmanager.go
+++ b/flag/service/alertmanager/alertmanager.go
@@ -1,5 +1,6 @@
 package alertmanager
 
 type AlertManager struct {
-	Address string
+	Address        string
+	Authentication string
 }

--- a/helm/silence-operator/templates/configmap.yaml
+++ b/helm/silence-operator/templates/configmap.yaml
@@ -16,6 +16,7 @@ data:
     service:
       alertmanager:
         address: {{ .Values.alertmanagerAddress }}
+        authentication: {{ .Values.alertmanagerAuthentication }}
       kubernetes:
         address: ''
         inCluster: true

--- a/helm/silence-operator/values.yaml
+++ b/helm/silence-operator/values.yaml
@@ -7,6 +7,7 @@ image:
   tag: "[[ .Version ]]"
 
 alertmanagerAddress: http://alertmanager-operated.monitoring.svc:9093
+alertmanagerAuthentication: false
 
 project:
   branch: "[[ .Branch ]]"

--- a/main.go
+++ b/main.go
@@ -129,6 +129,7 @@ func mainE(ctx context.Context) error {
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.TLS.KeyFile, "", "Key file path to use to authenticate with Kubernetes.")
 
 	daemonCommand.PersistentFlags().String(f.Service.AlertManager.Address, "http://localhost:9093", "Alertmanager address used to create silences.")
+	daemonCommand.PersistentFlags().Bool(f.Service.AlertManager.Authentication, false, "Enable Alertmanager authentication using Service Account token.")
 
 	err = newCommand.CobraCommand().Execute()
 	if err != nil {

--- a/service/controller/silence.go
+++ b/service/controller/silence.go
@@ -21,7 +21,8 @@ type SilenceConfig struct {
 	K8sClient k8sclient.Interface
 	Logger    micrologger.Logger
 
-	AlertManagerAddress string
+	AlertManagerAddress        string
+	AlertManagerAuthentication bool
 }
 
 type Silence struct {
@@ -68,7 +69,9 @@ func newSilenceResources(config SilenceConfig) ([]resource.Interface, error) {
 	var amClient *alertmanager.AlertManager
 	{
 		amConfig := alertmanager.Config{
-			Address: config.AlertManagerAddress,
+			Address:        config.AlertManagerAddress,
+			Authentication: config.AlertManagerAuthentication,
+			BearerToken:    config.K8sClient.RESTConfig().BearerToken,
 		}
 
 		amClient, err = alertmanager.New(amConfig)

--- a/service/service.go
+++ b/service/service.go
@@ -104,7 +104,8 @@ func New(config Config) (*Service, error) {
 			K8sClient: k8sClient,
 			Logger:    config.Logger,
 
-			AlertManagerAddress: config.Viper.GetString(config.Flag.Service.AlertManager.Address),
+			AlertManagerAddress:        config.Viper.GetString(config.Flag.Service.AlertManager.Address),
+			AlertManagerAuthentication: config.Viper.GetBool(config.Flag.Service.AlertManager.Authentication),
 		}
 
 		silenceController, err = controller.NewSilence(c)


### PR DESCRIPTION
Added option to use Service Account token for Alertmanager authentication, which is required for using silence-operator on OpenShift.

## Checklist

- [x] Update changelog in CHANGELOG.md.
