### PR TITLE
Disable sync job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Disable sync job
+
 ## [0.14.0] - 2025-03-31
 
 ### Changed

--- a/helm/silence-operator/values.yaml
+++ b/helm/silence-operator/values.yaml
@@ -16,7 +16,7 @@ project:
   commit: "[[ .SHA ]]"
 
 sync:
-  enabled: true
+  enabled: false
   repository: github.com/giantswarm/silences
   github:
     token: ""


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/30437

Disable silences sync job.

 :construction: On hold until Silences have been migrated to GitOps