### PR TITLE
Add Namespace Selector Feature for V2 Controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Allow filtering of `Silence` custom resources based on a label selector. The operator will only process `Silence` CRs that match the selector provided via the `--silence-selector` command-line flag or the `silenceSelector` Helm chart value. If no selector is provided, all `Silence` CRs are processed.
+- Add namespace selector feature for v2 controller to restrict which namespaces are watched for `observability.giantswarm.io/v1alpha2` Silence resources. Configure via `--namespace-selector` command-line flag or `namespaceSelector` Helm chart value. Supports standard Kubernetes label selectors for better multi-tenancy and resource isolation.
 - Add `observability.giantswarm.io/v1alpha2` API group with namespace-scoped Silence CRD.
 - Add `SilenceV2Reconciler` to handle v1alpha2 resources while maintaining backward compatibility with v1alpha1.
 - Add enhanced printer columns for better `kubectl get silences` output.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -71,6 +71,7 @@ func main() {
 
 	var cfg config.Config
 	var silenceSelector string
+	var namespaceSelector string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -92,6 +93,7 @@ func main() {
 	flag.StringVar(&cfg.TenantId, "alertmanager-default-tenant-id", "", "Alertmanager tenant id.")
 	flag.BoolVar(&cfg.Authentication, "alertmanager-authentication", false, "Enable Alertmanager authentication using Service Account token.")
 	flag.StringVar(&silenceSelector, "silence-selector", "", "Label selector to filter Silence custom resources (e.g., 'environment=production,tier=frontend').")
+	flag.StringVar(&namespaceSelector, "namespace-selector", "", "Label selector to restrict which namespaces the v2 controller watches (e.g., 'environment=production'). If empty, all namespaces are watched.")
 
 	opts := zap.Options{
 		Development: false,
@@ -99,12 +101,18 @@ func main() {
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
-	selector, err := config.ParseSilenceSelector(silenceSelector)
+	var err error
+	cfg.SilenceSelector, err = config.ParseSilenceSelector(silenceSelector)
 	if err != nil {
 		setupLog.Error(err, "failed to parse silence selector", "selector", silenceSelector)
 		os.Exit(1)
 	}
-	cfg.SilenceSelector = selector
+
+	cfg.NamespaceSelector, err = config.ParseNamespaceSelector(namespaceSelector)
+	if err != nil {
+		setupLog.Error(err, "failed to parse namespace selector", "selector", namespaceSelector)
+		os.Exit(1)
+	}
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
@@ -245,10 +253,11 @@ func main() {
 		os.Exit(1)
 	}
 	if err = (&controller.SilenceV2Reconciler{
-		Client:          mgr.GetClient(),
-		Scheme:          mgr.GetScheme(),
-		Alertmanager:    amClient,
-		SilenceSelector: cfg.SilenceSelector,
+		Client:            mgr.GetClient(),
+		Scheme:            mgr.GetScheme(),
+		Alertmanager:      amClient,
+		SilenceSelector:   cfg.SilenceSelector,
+		NamespaceSelector: cfg.NamespaceSelector,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "SilenceV2")
 		os.Exit(1)

--- a/helm/silence-operator/templates/deployment.yaml
+++ b/helm/silence-operator/templates/deployment.yaml
@@ -42,6 +42,9 @@ spec:
         {{- if .Values.silenceSelector }}
         - --silence-selector={{ .Values.silenceSelector }}
         {{- end }}
+        {{- if .Values.namespaceSelector }}
+        - --namespace-selector={{ .Values.namespaceSelector }}
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/helm/silence-operator/values.schema.json
+++ b/helm/silence-operator/values.schema.json
@@ -16,6 +16,11 @@
             "default": "",
             "description": "Label selector to filter Silence custom resources (e.g., 'environment=production,tier=frontend')."
         },
+        "namespaceSelector": {
+            "type": "string",
+            "default": "",
+            "description": "Label selector to restrict which namespaces the v2 controller watches (e.g., 'environment=production,team=platform')."
+        },
         "containerSecurityContext": {
             "type": "object",
             "properties": {

--- a/helm/silence-operator/values.yaml
+++ b/helm/silence-operator/values.yaml
@@ -26,6 +26,11 @@ alertmanagerDefaultTenant: ""
 # Example: 'environment=production,tier=frontend'
 silenceSelector: ""
 
+# Label selector to restrict which namespaces the v2 controller watches.
+# If empty, the v2 controller will watch all namespaces.
+# Example: 'environment=production' or 'team=platform,tier=monitoring'
+namespaceSelector: ""
+
 # -- Configures the pod security context
 podSecurityContext:
   runAsNonRoot: true

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,6 +14,9 @@ type Config struct {
 	TenantId       string
 	// SilenceSelector is used to filter silences based on label selectors.
 	SilenceSelector labels.Selector
+	// NamespaceSelector is used to restrict which namespaces the v2 controller watches.
+	// If nil, the controller will watch all namespaces.
+	NamespaceSelector labels.Selector
 }
 
 // ParseSilenceSelector parses a silence selector string into a labels.Selector.
@@ -31,6 +34,26 @@ func ParseSilenceSelector(silenceSelector string) (labels.Selector, error) {
 	selector, err := metav1.LabelSelectorAsSelector(parsedSelector)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to convert silence-selector to labels.Selector")
+	}
+
+	return selector, nil
+}
+
+// ParseNamespaceSelector parses a namespace selector string into a labels.Selector.
+// Returns nil if the selector is empty, which means all namespaces will be watched.
+func ParseNamespaceSelector(namespaceSelector string) (labels.Selector, error) {
+	if namespaceSelector == "" {
+		return nil, nil
+	}
+
+	parsedSelector, err := metav1.ParseToLabelSelector(namespaceSelector)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to parse namespace-selector string: %q", namespaceSelector)
+	}
+
+	selector, err := metav1.LabelSelectorAsSelector(parsedSelector)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to convert namespace-selector to labels.Selector")
 	}
 
 	return selector, nil


### PR DESCRIPTION
## Summary

This PR adds a namespace selector feature to the silence-operator's v2 controller, allowing users to restrict which namespaces the operator watches for `observability.giantswarm.io/v1alpha2` Silence resources. This provides better multi-tenancy and resource isolation capabilities. This will close https://github.com/giantswarm/silence-operator/pull/226

## Changes

### Core Implementation
- **Config Package**: Added `NamespaceSelector` field to `Config` struct and `ParseNamespaceSelector()` helper function with comprehensive test coverage (7 test cases)
- **Command Line Interface**: Added `--namespace-selector` flag to main.go with proper parsing and error handling
- **V2 Controller Enhancement**: 
  - Added `NamespaceSelector` field to `SilenceV2Reconciler` struct
  - Implemented two-level namespace filtering:
    1. **Controller-runtime level**: Predicate function that filters events before they reach reconcile
    2. **Reconcile level**: Additional backup check that validates namespace labels
  - Added comprehensive test coverage including namespace selector functionality

### Helm Chart Integration
- **Values Configuration**: Added `namespaceSelector` field to `values.yaml` with clear documentation and examples
- **Deployment Template**: Updated to conditionally pass `--namespace-selector` argument when configured
- **Schema Validation**: Added proper JSON schema validation in `values.schema.json`

### Documentation
- **README Updates**: Added comprehensive configuration section explaining both `silenceSelector` and `namespaceSelector` features with practical examples
- **Installation Examples**: Updated Helm installation examples to include namespace selector usage

## Key Features

### Namespace Filtering
- Supports standard Kubernetes label selectors (equality, set-based, etc.)
- Efficient filtering at controller-runtime level using predicates
- Only affects the v2 controller - v1 controller remains unchanged for backward compatibility

### Configuration Examples
```yaml
# Watch only production namespaces
namespaceSelector: "environment=production"

# Watch namespaces managed by platform team
namespaceSelector: "team=platform,tier=monitoring"

# Watch namespaces except test environments
namespaceSelector: "environment notin (test,staging)"
```

### Helm Integration
```bash
helm install silence-operator giantswarm/silence-operator \
  --set namespaceSelector="team=platform" \
  --set silenceSelector="environment=production"
```

## Testing

- ✅ All existing tests pass
- ✅ Added 7 new test cases for namespace selector parsing
- ✅ Added integration test for namespace selector in v2 controller
- ✅ Code compiles without errors
- ✅ Helm chart lints successfully

## Backward Compatibility

- No breaking changes - feature is opt-in via configuration
- V1 controller (`monitoring.giantswarm.io/v1alpha1`) continues to work unchanged
- V2 controller watches all namespaces by default (empty selector)
- Existing deployments continue to work without modification

## Impact

This enhancement enables better resource isolation and multi-tenancy by allowing operators to:
- Restrict monitoring to specific namespace subsets
- Reduce controller overhead by filtering irrelevant namespaces
- Implement team-based or environment-based silence management strategies
- Maintain clear separation between different workload tiers
