### PR TITLE
Helm Chart Scheduling and Deployment Enhancements

### DIFF
--- a/helm/silence-operator/templates/deployment.yaml
+++ b/helm/silence-operator/templates/deployment.yaml
@@ -19,15 +19,28 @@ spec:
       annotations:
         releaseRevision: {{ .Release.Revision | quote }}
     spec:
+      {{- if or .Values.affinity .Values.nodeAffinity }}
       affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  {{- include "labels.selector" . | nindent 18 }}
-              topologyKey: kubernetes.io/hostname
-            weight: 100
+        {{- with .Values.affinity }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.nodeAffinity }}
+        nodeAffinity:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      restartPolicy: {{ .Values.restartPolicy }}
       containers:
       - name: {{ template "silence-operator.name" . }}
         image: "{{ .Values.image.registry }}/{{ .Values.image.name }}:{{ default .Chart.Version .Values.image.tag }}"
@@ -46,11 +59,13 @@ spec:
         - --namespace-selector={{ .Values.namespaceSelector }}
         {{- end }}
         livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http-healthz
-          initialDelaySeconds: 30
-          timeoutSeconds: 1
+          {{- with .Values.livenessProbe }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+        readinessProbe:
+          {{- with .Values.readinessProbe }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
         ports:
         - containerPort: 8080
           name: http

--- a/helm/silence-operator/values.schema.json
+++ b/helm/silence-operator/values.schema.json
@@ -136,6 +136,43 @@
                 }
             }
         },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity configuration for pod scheduling"
+        },
+        "nodeAffinity": {
+            "type": "object",
+            "description": "Node affinity configuration for pod scheduling"
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node selector for pod scheduling"
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for pod scheduling",
+            "items": {
+                "type": "object"
+            }
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "Priority class name for pod scheduling"
+        },
+        "livenessProbe": {
+            "type": "object",
+            "description": "Configures liveness probe"
+        },
+        "readinessProbe": {
+            "type": "object",
+            "description": "Configures readiness probe"
+        },
+        "restartPolicy": {
+            "type": "string",
+            "description": "Restart policy for the pod",
+            "enum": ["Always", "OnFailure", "Never"],
+            "default": "Always"
+        },
         "crds": {
             "type": "object",
             "properties": {

--- a/helm/silence-operator/values.yaml
+++ b/helm/silence-operator/values.yaml
@@ -63,6 +63,56 @@ resources:
     cpu: 50m
     memory: 100Mi
 
+# -- Affinity configuration for pod scheduling
+# Since this operator runs as a single instance, anti-affinity is disabled by default
+affinity: {}
+
+# -- Node affinity configuration for pod scheduling
+# Example:
+# nodeAffinity:
+#   requiredDuringSchedulingIgnoredDuringExecution:
+#     nodeSelectorTerms:
+#     - matchExpressions:
+#       - key: kubernetes.io/arch
+#         operator: In
+#         values: ["amd64", "arm64"]
+nodeAffinity: {}
+
+# -- Node selector for pod scheduling
+nodeSelector: {}
+
+# -- Tolerations for pod scheduling
+tolerations: []
+
+# -- Priority class name for pod scheduling
+# Example: system-cluster-critical, system-node-critical
+priorityClassName: ""
+
+# -- Configures liveness probe
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: http-healthz
+  initialDelaySeconds: 30
+  timeoutSeconds: 1
+  periodSeconds: 10
+  successThreshold: 1
+  failureThreshold: 3
+
+# -- Configures readiness probe
+readinessProbe:
+  httpGet:
+    path: /readyz
+    port: http-healthz
+  initialDelaySeconds: 5
+  timeoutSeconds: 1
+  periodSeconds: 5
+  successThreshold: 1
+  failureThreshold: 3
+
+# -- Restart policy for the pod (Always for single-instance reliability)
+restartPolicy: Always
+
 rbac:
   create: true
 


### PR DESCRIPTION


## Summary
Enhanced Helm chart with configurable scheduling options for single-instance deployments.

## Changes Made

### 1. Enhanced `values.yaml`
- Added `nodeAffinity: {}` with documentation examples
- Added `priorityClassName: ""` for critical workload support
- Enhanced `livenessProbe` and `readinessProbe` with full customization
- Added `restartPolicy: Always` for single-instance reliability

### 2. Updated Deployment Template
- Replaced hardcoded pod anti-affinity with configurable affinity logic
- Added conditional rendering for priority class and restart policy
- Enhanced probe configurations using `toYaml` for full customization
- Proper template logic to only render affinity block when needed

### 3. Schema Validation
- Updated `values.schema.json` with all new fields and proper types
- Added descriptions for each configuration option

### 4. Documentation Updates
- Updated `IMPROVEMENT_IDEAS.md` to mark item #4 as completed
- Separated multi-architecture support into new item #17
- Renamed item #4 to "Scheduling and Deployment Enhancements"

## Key Features Added
- **Node Affinity**: Configure pod placement on specific nodes
- **Priority Classes**: Support for `system-cluster-critical` and `system-node-critical`
- **Enhanced Probes**: Fully customizable health check configurations
- **Restart Policy**: Configurable restart behavior for single-instance reliability

## Testing
- ✅ Helm chart linting passes with strict mode
- ✅ Template rendering validated with various configurations
- ✅ All new values render correctly in deployment

## Files Modified
- `helm/silence-operator/values.yaml`
- `helm/silence-operator/templates/deployment.yaml`
- `helm/silence-operator/values.schema.json`

## Notes
This operator runs as a single instance (no HA mode). All enhancements are designed for single-instance deployments with improved scheduling control and reliability.
