### PR TITLE
feat(helm): make deployment strategy configurable and switch to 'RollingUpdate'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- [Helm] Ability to specify deployment (rollout) strategy and switch from 'Recreate' to 'RollingUpdate' by default.
+
 ## [0.19.0] - 2025-09-17
 
 ### Added

--- a/helm/silence-operator/templates/ciliumnetworkpolicy.yaml
+++ b/helm/silence-operator/templates/ciliumnetworkpolicy.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.networkPolicy.enabled (eq .Values.networkPolicy.flavor "cilium") }}
+{{- if and .Values.networkPolicy.enabled (eq .Values.networkPolicy.flavor "cilium") -}}
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -23,4 +23,4 @@ spec:
         http:
         - method: "GET"
           path: "/metrics"
-{{- end }}
+{{- end -}}

--- a/helm/silence-operator/templates/crds.yml
+++ b/helm/silence-operator/templates/crds.yml
@@ -1,4 +1,4 @@
-{{- if .Values.crds.install }}
+{{- if .Values.crds.install -}}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -180,4 +180,4 @@ spec:
     served: true
     storage: true
     subresources: {}
-{{- end }}
+{{- end -}}

--- a/helm/silence-operator/templates/deployment.yaml
+++ b/helm/silence-operator/templates/deployment.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm/silence-operator/templates/deployment.yaml
+++ b/helm/silence-operator/templates/deployment.yaml
@@ -11,8 +11,10 @@ spec:
   selector:
     matchLabels:
       {{- include "labels.selector" . | nindent 6 }}
+  {{- with .Values.strategy }}
   strategy:
-    type: Recreate
+    {{- toYaml . | trim | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/helm/silence-operator/templates/networkpolicy.yaml
+++ b/helm/silence-operator/templates/networkpolicy.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.networkPolicy.enabled (eq .Values.networkPolicy.flavor "kubernetes") }}
+{{- if and .Values.networkPolicy.enabled (eq .Values.networkPolicy.flavor "kubernetes") -}}
+---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -19,4 +20,4 @@ spec:
   policyTypes:
   - Egress
   - Ingress
-{{- end }}
+{{- end -}}

--- a/helm/silence-operator/templates/pod-monitor.yaml
+++ b/helm/silence-operator/templates/pod-monitor.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.podMonitor.enabled }}
+{{- if .Values.podMonitor.enabled -}}
+---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
@@ -15,4 +16,4 @@ spec:
       {{- include "labels.selector" . | nindent 6 }}
   podMetricsEndpoints:
     - port: http
-{{ end }}
+{{- end -}}

--- a/helm/silence-operator/templates/rbac.yaml
+++ b/helm/silence-operator/templates/rbac.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.rbac.create -}}
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -40,4 +41,4 @@ roleRef:
   kind: ClusterRole
   name: {{ template "silence-operator.name" . }}
   apiGroup: rbac.authorization.k8s.io
-{{- end }}
+{{- end -}}

--- a/helm/silence-operator/templates/service-account.yaml
+++ b/helm/silence-operator/templates/service-account.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/helm/silence-operator/values.yaml
+++ b/helm/silence-operator/values.yaml
@@ -18,6 +18,10 @@ image:
 # Deployment replicas
 replicas: 1
 
+# Deployment strategy
+strategy:
+  type: RollingUpdate
+
 # TODO improve this for better user experience
 alertmanagerAddress: ""
 alertmanagerAuthentication: false


### PR DESCRIPTION
As silence-operator implements leader-election, 'RollingUpdate' is favorable as multiple replicas would be rolled out graceful (usually one by one).

Notes: Please check both commits individually as the changes are split accordingly.

## Checklist

- [x] Update changelog in CHANGELOG.md.
