### PR TITLE
feat: configurable silence expiration time and leader election toggle

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -96,6 +96,8 @@ func main() {
 	flag.BoolVar(&cfg.Authentication, "alertmanager-authentication", false, "Enable Alertmanager authentication using Service Account token.")
 	flag.StringVar(&silenceSelector, "silence-selector", "", "Label selector to filter Silence custom resources (e.g., 'environment=production,tier=frontend').")
 	flag.StringVar(&namespaceSelector, "namespace-selector", "", "Label selector to restrict which namespaces the v2 controller watches (e.g., 'environment=production'). If empty, all namespaces are watched.")
+	flag.StringVar(&cfg.ExpirationTime, "expiration-time", "08:00Z",
+		"Time of day at which date-only 'valid-until' silences expire, in ISO 8601 HH:MM±HH:MM format (e.g. '08:00Z', '08:00+01:00'). Default: '08:00Z'.")
 	// Tenancy flags (not wired up yet - for future PRs)
 	flag.BoolVar(&cfg.TenancyEnabled, "tenancy-enabled", false, "Enable tenancy support for multi-tenant Alertmanager setups.")
 	flag.StringVar(&cfg.TenancyLabelKey, "tenancy-label-key", "observability.giantswarm.io/tenant", "Label key to extract tenant information from Silence resources.")

--- a/helm/silence-operator/templates/deployment.yaml
+++ b/helm/silence-operator/templates/deployment.yaml
@@ -48,7 +48,9 @@ spec:
       - name: {{ template "silence-operator.name" . }}
         image: "{{ if .Values.image.registry }}{{ .Values.image.registry }}/{{ end }}{{ .Values.image.name }}:{{ default .Chart.AppVersion .Values.image.tag }}"
         args:
+        {{- if .Values.leaderElection }}
         - --leader-elect
+        {{- end }}
         - --metrics-bind-address=:8080
         - --alertmanager-address={{ .Values.alertmanagerAddress }}
         - --alertmanager-authentication={{ .Values.alertmanagerAuthentication }}
@@ -73,6 +75,7 @@ spec:
         {{- if .Values.namespaceSelector }}
         - --namespace-selector={{ .Values.namespaceSelector }}
         {{- end }}
+        - --expiration-time={{ .Values.expirationTime }}
         livenessProbe:
           {{- with .Values.livenessProbe }}
           {{- toYaml . | nindent 10 }}

--- a/helm/silence-operator/values.yaml
+++ b/helm/silence-operator/values.yaml
@@ -135,6 +135,15 @@ readinessProbe:
 # -- Restart policy for the pod (Always for single-instance reliability)
 restartPolicy: Always
 
+# Whether to enable leader election (recommended for multi-replica deployments).
+# Disable for single-instance dev setups or when leader election is managed externally.
+leaderElection: true
+
+# Time of day at which date-only 'valid-until' silences expire (ISO 8601 HH:MM±HH:MM).
+# Default 08:00Z = 8am UTC (9 CET / 10 CEST) to avoid overnight expiration.
+# Examples: "08:00Z", "08:00+01:00", "06:00-05:00"
+expirationTime: "08:00Z"
+
 rbac:
   create: true
 

--- a/internal/controller/silence_controller.go
+++ b/internal/controller/silence_controller.go
@@ -141,7 +141,7 @@ func (r *SilenceReconciler) cleanUpLegacyFinalizer(ctx context.Context, silence 
 func (r *SilenceReconciler) reconcileCreate(ctx context.Context, silence *v1alpha1.Silence) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
-	newSilence, err := getSilenceFromCR(silence)
+	newSilence, err := getSilenceFromCR(silence, r.silenceService)
 	if err != nil {
 		return ctrl.Result{}, errors.WithStack(err)
 	}
@@ -180,7 +180,7 @@ func (r *SilenceReconciler) reconcileDelete(ctx context.Context, silence *v1alph
 	return nil
 }
 
-func getSilenceFromCR(silence *v1alpha1.Silence) (*alertmanager.Silence, error) {
+func getSilenceFromCR(silence *v1alpha1.Silence, svc *service.SilenceService) (*alertmanager.Silence, error) {
 	var matchers []alertmanager.Matcher
 	for _, matcher := range silence.Spec.Matchers {
 		isEqual := true
@@ -196,7 +196,7 @@ func getSilenceFromCR(silence *v1alpha1.Silence) (*alertmanager.Silence, error) 
 		matchers = append(matchers, newMatcher)
 	}
 
-	endsAt, err := alertmanager.SilenceEndsAt(silence)
+	endsAt, err := svc.SilenceEndsAt(silence)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/internal/controller/silence_controller_test.go
+++ b/internal/controller/silence_controller_test.go
@@ -564,7 +564,7 @@ var _ = Describe("Silence Controller", func() {
 			}
 
 			By("converting CR to alertmanager Silence")
-			silence, err := getSilenceFromCR(cr)
+			silence, err := getSilenceFromCR(cr, reconciler.silenceService)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(silence).NotTo(BeNil())
 

--- a/internal/controller/silence_v2_controller.go
+++ b/internal/controller/silence_v2_controller.go
@@ -187,7 +187,7 @@ func (r *SilenceV2Reconciler) getSilenceFromCR(silence *v1alpha2.Silence) (*aler
 		})
 	}
 
-	endsAt, err := alertmanager.SilenceEndsAt(silence)
+	endsAt, err := r.silenceService.SilenceEndsAt(silence)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -38,17 +38,21 @@ type Client interface {
 	DeleteSilenceByComment(comment string, tenant string) error
 	DeleteSilenceByID(id string, tenant string) error
 	ListSilences(tenant string) ([]Silence, error)
+	SilenceEndsAt(silence client.Object) (time.Time, error)
 }
 
 // Ensure Alertmanager implements Client
 var _ Client = (*Alertmanager)(nil)
 
 type Alertmanager struct {
-	address        string
-	authentication bool
-	token          string
-	tenantId       string
-	client         *http.Client
+	address           string
+	authentication    bool
+	token             string
+	tenantId          string
+	client            *http.Client
+	expirationHour    int
+	expirationMinute  int
+	expirationLoc     *time.Location
 }
 
 func New(config config.Config) (*Alertmanager, error) {
@@ -56,12 +60,32 @@ func New(config config.Config) (*Alertmanager, error) {
 		return nil, errors.Errorf("%T.Address must not be empty", config)
 	}
 
+	expirationTime := config.ExpirationTime
+	if expirationTime == "" {
+		expirationTime = "08:00Z"
+	}
+
+	parsed, err := time.Parse("15:04Z07:00", expirationTime)
+	if err != nil {
+		return nil, errors.Wrapf(err, "invalid expiration-time %q: must be ISO 8601 HH:MM±HH:MM (e.g. \"08:00Z\", \"08:00+01:00\")", expirationTime)
+	}
+	_, offsetSeconds := parsed.Zone()
+	var loc *time.Location
+	if offsetSeconds == 0 {
+		loc = time.UTC
+	} else {
+		loc = time.FixedZone(fmt.Sprintf("%+03d:%02d", offsetSeconds/3600, (offsetSeconds%3600)/60), offsetSeconds)
+	}
+
 	return &Alertmanager{
-		address:        config.Address,
-		authentication: config.Authentication,
-		token:          config.BearerToken,
-		client:         http.DefaultClient,
-		tenantId:       config.TenantId,
+		address:          config.Address,
+		authentication:   config.Authentication,
+		token:            config.BearerToken,
+		client:           http.DefaultClient,
+		tenantId:         config.TenantId,
+		expirationHour:   parsed.Hour(),
+		expirationMinute: parsed.Minute(),
+		expirationLoc:    loc,
 	}, nil
 }
 
@@ -211,7 +235,7 @@ func SilenceComment(silence client.Object) string {
 // The expiry date is retrieved from the annotation name configured by ValidUntilAnnotationName.
 // The expected format is defined by DateOnlyLayout.
 // It returns an invalidExpirationDateError in case the date format is invalid.
-func SilenceEndsAt(silence client.Object) (time.Time, error) {
+func (am *Alertmanager) SilenceEndsAt(silence client.Object) (time.Time, error) {
 	annotations := silence.GetAnnotations()
 
 	// Check if the annotation exist otherwise return a date 100 years in the future.
@@ -232,8 +256,7 @@ func SilenceEndsAt(silence client.Object) (time.Time, error) {
 		// Combine both errors in the message. Wrap errRFC3339 to preserve stack trace.
 		return time.Time{}, errors.Wrapf(errRFC3339, "annotation %q date %q does not match expected formats %q or %q (legacy format error: %v)", ValidUntilAnnotationName, value, time.RFC3339, DateOnlyLayout, errDateOnly)
 	}
-	// We shift the time to 8am UTC (9 CET or 10 CEST) to ensure silences do not expire at night.
-	// TODO move this rule to a config?
-	expirationDate = time.Date(expirationDate.Year(), expirationDate.Month(), expirationDate.Day(), 8, 0, 0, 0, time.UTC)
+	// Shift to the configured expiration time to ensure silences do not expire at night.
+	expirationDate = time.Date(expirationDate.Year(), expirationDate.Month(), expirationDate.Day(), am.expirationHour, am.expirationMinute, 0, 0, am.expirationLoc)
 	return expirationDate, nil
 }

--- a/pkg/alertmanager/alertmanager_test.go
+++ b/pkg/alertmanager/alertmanager_test.go
@@ -47,6 +47,30 @@ func TestNew(t *testing.T) {
 			},
 			expectError: true,
 		},
+		{
+			name: "valid expiration time UTC",
+			config: config.Config{
+				Address:        "http://localhost:9093",
+				ExpirationTime: "08:00Z",
+			},
+			expectError: false,
+		},
+		{
+			name: "valid expiration time with positive offset",
+			config: config.Config{
+				Address:        "http://localhost:9093",
+				ExpirationTime: "08:00+01:00",
+			},
+			expectError: false,
+		},
+		{
+			name: "invalid expiration time",
+			config: config.Config{
+				Address:        "http://localhost:9093",
+				ExpirationTime: "not-a-time",
+			},
+			expectError: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -141,9 +165,12 @@ func TestSilenceEndsAt(t *testing.T) {
 		},
 	}
 
+	am, err := New(config.Config{Address: "http://localhost:9093"})
+	require.NoError(t, err)
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := SilenceEndsAt(tt.silence)
+			result, err := am.SilenceEndsAt(tt.silence)
 
 			if tt.expectError {
 				assert.Error(t, err)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,6 +20,10 @@ type Config struct {
 	// If nil, the controller will watch all namespaces.
 	NamespaceSelector labels.Selector
 
+	// ExpirationTime is the time of day at which date-only 'valid-until' silences expire.
+	// Must be in ISO 8601 HH:MM±HH:MM format (e.g. "08:00Z", "08:00+01:00"). Default: "08:00Z".
+	ExpirationTime string
+
 	// Tenancy configuration
 	TenancyEnabled       bool
 	TenancyLabelKey      string // Single label key to extract tenant from (e.g., "observability.giantswarm.io/tenant")

--- a/pkg/service/silence.go
+++ b/pkg/service/silence.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/giantswarm/silence-operator/pkg/alertmanager"
 )
@@ -77,6 +78,11 @@ func (s *SilenceService) SyncSilence(ctx context.Context, newSilence *alertmanag
 
 	// No changes needed
 	return nil
+}
+
+// SilenceEndsAt delegates to the alertmanager client to compute the expiry time for a silence.
+func (s *SilenceService) SilenceEndsAt(silence client.Object) (time.Time, error) {
+	return s.alertmanager.SilenceEndsAt(silence)
 }
 
 // DeleteSilence handles the deletion of a silence


### PR DESCRIPTION
## Summary

- **Configurable expiration time**: Replaces the hardcoded 8am UTC shift (applied to date-only `valid-until` annotations) with a new `--expiration-time` flag accepting ISO 8601 `HH:MM±HH:MM` format (e.g. `08:00Z`, `08:00+01:00`). Default is `08:00Z` — no behaviour change for existing deployments.
- **Leader election toggle in Helm**: `--leader-elect` was hardcoded in the deployment template; it is now controlled by a `leaderElection` Helm value (default `true`) so single-instance dev setups can disable it.

## Changes

- `pkg/config/config.go` — added `ExpirationTime string` field
- `pkg/alertmanager/alertmanager.go` — `SilenceEndsAt` promoted from a package-level function to a method on `Alertmanager` (parses ISO 8601 offset in `New()`); added to `Client` interface
- `pkg/service/silence.go` — `SilenceEndsAt` delegation method so controllers go through the service
- `internal/controller/silence_controller.go` — `getSilenceFromCR` takes `*service.SilenceService`
- `internal/controller/silence_v2_controller.go` — calls `r.silenceService.SilenceEndsAt`
- `cmd/main.go` — `--expiration-time` flag (default `08:00Z`)
- `helm/silence-operator/values.yaml` — `leaderElection: true`, `expirationTime: "08:00Z"`
- `helm/silence-operator/templates/deployment.yaml` — conditional `--leader-elect`, passes `--expiration-time`