### PR TITLE
feat: validating admission webhook for v1alpha2 Silences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add validating admission webhook for `v1alpha2` Silences that enforces business rules not expressible in OpenAPI schema: no duplicate matchers, valid regular expressions for `=~`/`!~` matchers, parseable `valid-until` annotation, and non-past expiry on CREATE. Enabled automatically when `webhook.enabled=true`.
 - Add mutating admission webhook for `v1alpha2` Silences that injects matchers, labels, and annotations on CREATE/UPDATE via configurable CEL rules, replacing the Kyverno policy in `kyverno-policies-observability`.
   - Disabled by default. Enable with `webhook.enabled=true` and configure rules in `webhook.celRules`.
   - Rules with an empty `condition` apply unconditionally (Kyverno parity); non-empty conditions are evaluated as CEL expressions against the incoming object.

--- a/api/v1alpha2/silence_validator.go
+++ b/api/v1alpha2/silence_validator.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha2
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// These constants mirror pkg/alertmanager to avoid a downward dependency from
+// the API package into pkg. The DDD/DRY pass should move them to a shared location.
+const (
+	validUntilAnnotation = "valid-until"
+	dateOnlyLayout       = "2006-01-02"
+)
+
+// +kubebuilder:webhook:path=/validate-observability-giantswarm-io-v1alpha2-silence,mutating=false,failurePolicy=fail,sideEffects=None,groups=observability.giantswarm.io,resources=silences,verbs=create;update,versions=v1alpha2,name=vsilence.observability.giantswarm.io,admissionReviewVersions=v1
+
+// SilenceValidator enforces business-rule constraints that cannot be expressed
+// in the OpenAPI/CRD schema:
+//
+//   - No duplicate matchers (same name+value+matchType).
+//   - Regex matchers (=~ / !~) must be valid Go regular expressions.
+//   - The valid-until annotation, if present, must be parseable as RFC3339 or
+//     date-only (YYYY-MM-DD).
+//   - On CREATE: valid-until must not already be in the past.
+type SilenceValidator struct{}
+
+var _ admission.Validator[*Silence] = &SilenceValidator{}
+
+// SetupWebhookWithManager registers the validating webhook with the manager.
+func (v *SilenceValidator) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr, &Silence{}).
+		WithValidator(v).
+		Complete()
+}
+
+func (v *SilenceValidator) ValidateCreate(ctx context.Context, silence *Silence) (admission.Warnings, error) {
+	return validateSilence(silence, true)
+}
+
+func (v *SilenceValidator) ValidateUpdate(_ context.Context, _, newSilence *Silence) (admission.Warnings, error) {
+	return validateSilence(newSilence, false)
+}
+
+func (v *SilenceValidator) ValidateDelete(_ context.Context, _ *Silence) (admission.Warnings, error) {
+	return nil, nil
+}
+
+// validateSilence runs all validations and aggregates errors.
+// isCreate controls whether the "valid-until not in the past" check applies.
+func validateSilence(silence *Silence, isCreate bool) (admission.Warnings, error) {
+	var errs []string
+	errs = append(errs, validateNoDuplicateMatchers(silence.Spec.Matchers)...)
+	errs = append(errs, validateRegexMatchers(silence.Spec.Matchers)...)
+	errs = append(errs, validateValidUntil(silence, isCreate)...)
+	if len(errs) > 0 {
+		return nil, fmt.Errorf("Silence %q is invalid: %s", silence.Name, strings.Join(errs, "; "))
+	}
+	return nil, nil
+}
+
+// validateNoDuplicateMatchers rejects matchers that are identical in
+// name, value, and matchType.
+func validateNoDuplicateMatchers(matchers []SilenceMatcher) []string {
+	var errs []string
+	seen := make(map[string]int) // key → first index
+	for i, m := range matchers {
+		key := m.Name + "|" + m.Value + "|" + string(m.MatchType)
+		if first, ok := seen[key]; ok {
+			errs = append(errs, fmt.Sprintf(
+				"spec.matchers[%d] duplicates spec.matchers[%d] (name=%q value=%q matchType=%q)",
+				i, first, m.Name, m.Value, m.MatchType,
+			))
+		} else {
+			seen[key] = i
+		}
+	}
+	return errs
+}
+
+// validateRegexMatchers checks that =~ and !~ matchers contain a valid Go regex.
+func validateRegexMatchers(matchers []SilenceMatcher) []string {
+	var errs []string
+	for i, m := range matchers {
+		if m.MatchType == MatchRegexMatch || m.MatchType == MatchRegexNotMatch {
+			if _, err := regexp.Compile(m.Value); err != nil {
+				errs = append(errs, fmt.Sprintf(
+					"spec.matchers[%d]: matchType %q requires a valid regular expression, %q does not compile: %v",
+					i, m.MatchType, m.Value, err,
+				))
+			}
+		}
+	}
+	return errs
+}
+
+// validateValidUntil checks that the valid-until annotation is parseable, and
+// on CREATE that the resulting expiry time is not already in the past.
+func validateValidUntil(silence *Silence, isCreate bool) []string {
+	val, ok := silence.GetAnnotations()[validUntilAnnotation]
+	if !ok || val == "" {
+		return nil
+	}
+
+	var expiry time.Time
+
+	// Try RFC3339 first (e.g. 2026-12-31T08:00:00Z).
+	if t, err := time.Parse(time.RFC3339, val); err == nil {
+		expiry = t
+	} else {
+		// Fall back to date-only (e.g. 2026-12-31).  The controller shifts
+		// date-only values to 08:00 UTC when computing the actual Alertmanager
+		// end-time, so we apply the same shift here for consistency.
+		t, dateErr := time.Parse(dateOnlyLayout, val)
+		if dateErr != nil {
+			return []string{fmt.Sprintf(
+				"annotation %q: %q is not a valid date; accepted formats are RFC3339 (e.g. 2026-12-31T08:00:00Z) or date-only (e.g. 2026-12-31)",
+				validUntilAnnotation, val,
+			)}
+		}
+		expiry = time.Date(t.Year(), t.Month(), t.Day(), 8, 0, 0, 0, time.UTC)
+	}
+
+	if isCreate && expiry.Before(time.Now()) {
+		return []string{fmt.Sprintf(
+			"annotation %q: expiry time %q is already in the past",
+			validUntilAnnotation, val,
+		)}
+	}
+	return nil
+}

--- a/api/v1alpha2/silence_validator_test.go
+++ b/api/v1alpha2/silence_validator_test.go
@@ -1,0 +1,205 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha2
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var v = &SilenceValidator{}
+
+func silence(matchers ...SilenceMatcher) *Silence {
+	return &Silence{
+		ObjectMeta: metav1.ObjectMeta{Name: "test"},
+		Spec:       SilenceSpec{Matchers: matchers},
+	}
+}
+
+func matcher(name, value string, mt MatchType) SilenceMatcher {
+	return SilenceMatcher{Name: name, Value: value, MatchType: mt}
+}
+
+func withAnnotation(s *Silence, key, val string) *Silence {
+	if s.Annotations == nil {
+		s.Annotations = map[string]string{}
+	}
+	s.Annotations[key] = val
+	return s
+}
+
+// --- ValidateCreate: valid input ---
+
+func TestValidateCreate_Valid(t *testing.T) {
+	s := silence(matcher("alertname", "HighCPU", MatchEqual))
+	_, err := v.ValidateCreate(context.Background(), s)
+	require.NoError(t, err)
+}
+
+// --- Duplicate matchers ---
+
+func TestValidateCreate_DuplicateMatcher(t *testing.T) {
+	s := silence(
+		matcher("alertname", "HighCPU", MatchEqual),
+		matcher("alertname", "HighCPU", MatchEqual),
+	)
+	_, err := v.ValidateCreate(context.Background(), s)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicates")
+	assert.Contains(t, err.Error(), "spec.matchers[1]")
+}
+
+func TestValidateCreate_SameNameDifferentValue_OK(t *testing.T) {
+	s := silence(
+		matcher("alertname", "HighCPU", MatchEqual),
+		matcher("alertname", "LowMemory", MatchEqual),
+	)
+	_, err := v.ValidateCreate(context.Background(), s)
+	require.NoError(t, err)
+}
+
+func TestValidateCreate_SameNameValueDifferentMatchType_OK(t *testing.T) {
+	s := silence(
+		matcher("alertname", "Heartbeat", MatchEqual),
+		matcher("alertname", "Heartbeat", MatchNotEqual),
+	)
+	_, err := v.ValidateCreate(context.Background(), s)
+	require.NoError(t, err)
+}
+
+func TestValidateCreate_MultipleDuplicates_AllReported(t *testing.T) {
+	s := silence(
+		matcher("a", "1", MatchEqual),
+		matcher("b", "2", MatchEqual),
+		matcher("a", "1", MatchEqual), // dup of [0]
+		matcher("b", "2", MatchEqual), // dup of [1]
+	)
+	_, err := v.ValidateCreate(context.Background(), s)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "spec.matchers[2]")
+	assert.Contains(t, err.Error(), "spec.matchers[3]")
+}
+
+// --- Regex matchers ---
+
+func TestValidateCreate_ValidRegex(t *testing.T) {
+	s := silence(matcher("alertname", "High.*", MatchRegexMatch))
+	_, err := v.ValidateCreate(context.Background(), s)
+	require.NoError(t, err)
+}
+
+func TestValidateCreate_InvalidRegex(t *testing.T) {
+	s := silence(matcher("alertname", "[invalid", MatchRegexMatch))
+	_, err := v.ValidateCreate(context.Background(), s)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not compile")
+}
+
+func TestValidateCreate_InvalidNegativeRegex(t *testing.T) {
+	s := silence(matcher("alertname", "(unclosed", MatchRegexNotMatch))
+	_, err := v.ValidateCreate(context.Background(), s)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not compile")
+}
+
+func TestValidateCreate_EqualMatchType_RegexNotValidated(t *testing.T) {
+	// = and != matchers treat value as a literal string, not a regex.
+	s := silence(matcher("alertname", "[not-validated-as-regex", MatchEqual))
+	_, err := v.ValidateCreate(context.Background(), s)
+	require.NoError(t, err)
+}
+
+// --- valid-until annotation ---
+
+func TestValidateCreate_ValidUntil_RFC3339_Future(t *testing.T) {
+	s := withAnnotation(silence(matcher("a", "b", MatchEqual)), validUntilAnnotation, "2099-12-31T08:00:00Z")
+	_, err := v.ValidateCreate(context.Background(), s)
+	require.NoError(t, err)
+}
+
+func TestValidateCreate_ValidUntil_DateOnly_Future(t *testing.T) {
+	s := withAnnotation(silence(matcher("a", "b", MatchEqual)), validUntilAnnotation, "2099-12-31")
+	_, err := v.ValidateCreate(context.Background(), s)
+	require.NoError(t, err)
+}
+
+func TestValidateCreate_ValidUntil_RFC3339_Past(t *testing.T) {
+	s := withAnnotation(silence(matcher("a", "b", MatchEqual)), validUntilAnnotation, "2020-01-01T00:00:00Z")
+	_, err := v.ValidateCreate(context.Background(), s)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already in the past")
+}
+
+func TestValidateCreate_ValidUntil_DateOnly_Past(t *testing.T) {
+	s := withAnnotation(silence(matcher("a", "b", MatchEqual)), validUntilAnnotation, "2020-01-01")
+	_, err := v.ValidateCreate(context.Background(), s)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already in the past")
+}
+
+func TestValidateCreate_ValidUntil_InvalidFormat(t *testing.T) {
+	s := withAnnotation(silence(matcher("a", "b", MatchEqual)), validUntilAnnotation, "not-a-date")
+	_, err := v.ValidateCreate(context.Background(), s)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a valid date")
+}
+
+func TestValidateCreate_ValidUntil_Absent_OK(t *testing.T) {
+	s := silence(matcher("a", "b", MatchEqual))
+	_, err := v.ValidateCreate(context.Background(), s)
+	require.NoError(t, err)
+}
+
+// --- UPDATE does not apply the "in the past" check ---
+
+func TestValidateUpdate_ValidUntil_Past_Allowed(t *testing.T) {
+	// Updating a Silence that already has an expired valid-until should succeed:
+	// the controller will expire it naturally; the webhook must not block updates.
+	old := withAnnotation(silence(matcher("a", "b", MatchEqual)), validUntilAnnotation, "2020-01-01T00:00:00Z")
+	updated := withAnnotation(silence(matcher("a", "b", MatchEqual), matcher("c", "d", MatchEqual)), validUntilAnnotation, "2020-01-01T00:00:00Z")
+	_, err := v.ValidateUpdate(context.Background(), old, updated)
+	require.NoError(t, err)
+}
+
+// --- DELETE is always allowed ---
+
+func TestValidateDelete_AlwaysAllowed(t *testing.T) {
+	s := silence(matcher("a", "b", MatchEqual))
+	_, err := v.ValidateDelete(context.Background(), s)
+	require.NoError(t, err)
+}
+
+// --- Multiple errors aggregated ---
+
+func TestValidateCreate_MultipleErrors_AllReported(t *testing.T) {
+	s := withAnnotation(
+		silence(
+			matcher("alertname", "[bad-regex", MatchRegexMatch),
+			matcher("alertname", "[bad-regex", MatchRegexMatch), // also a duplicate
+		),
+		validUntilAnnotation, "not-a-date",
+	)
+	_, err := v.ValidateCreate(context.Background(), s)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicates")
+	assert.Contains(t, err.Error(), "does not compile")
+	assert.Contains(t, err.Error(), "not a valid date")
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -76,6 +76,7 @@ func main() {
 	var silenceSelector string
 	var namespaceSelector string
 	var webhookCELRulesJSON string
+	var webhookValidatingEnabled bool
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -100,6 +101,8 @@ func main() {
 	flag.StringVar(&namespaceSelector, "namespace-selector", "", "Label selector to restrict which namespaces the v2 controller watches (e.g., 'environment=production'). If empty, all namespaces are watched.")
 	flag.StringVar(&webhookCELRulesJSON, "webhook-cel-rules", "[]",
 		"JSON array of CEL mutation rules applied to every Silence on CREATE/UPDATE. Each rule has: name, condition (CEL expr on 'object'; empty = always apply), matchers, labels, annotations. Webhook is disabled when this is an empty array.")
+	flag.BoolVar(&webhookValidatingEnabled, "webhook-validating-enabled", false,
+		"Enable the validating webhook for v1alpha2 Silences (duplicate matchers, regex validity, valid-until annotation).")
 	// Tenancy flags (not wired up yet - for future PRs)
 	flag.BoolVar(&cfg.TenancyEnabled, "tenancy-enabled", false, "Enable tenancy support for multi-tenant Alertmanager setups.")
 	flag.StringVar(&cfg.TenancyLabelKey, "tenancy-label-key", "observability.giantswarm.io/tenant", "Label key to extract tenant information from Silence resources.")
@@ -289,6 +292,15 @@ func main() {
 		setupLog.Info("mutating webhook registered", "celRules", len(webhookCfg.CELRules))
 	} else {
 		setupLog.Info("mutating webhook disabled (no CEL rules configured)")
+	}
+
+	if webhookValidatingEnabled {
+		validator := &observabilityv1alpha2.SilenceValidator{}
+		if err = validator.SetupWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to register webhook", "webhook", "SilenceValidating")
+			os.Exit(1)
+		}
+		setupLog.Info("validating webhook registered")
 	}
 
 	if metricsCertWatcher != nil {

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -24,3 +24,29 @@ webhooks:
     resources:
     - silences
   sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-observability-giantswarm-io-v1alpha2-silence
+  failurePolicy: Fail
+  name: vsilence.observability.giantswarm.io
+  rules:
+  - apiGroups:
+    - observability.giantswarm.io
+    apiVersions:
+    - v1alpha2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - silences
+  sideEffects: None

--- a/helm/silence-operator/templates/ciliumnetworkpolicy.yaml
+++ b/helm/silence-operator/templates/ciliumnetworkpolicy.yaml
@@ -23,4 +23,10 @@ spec:
         http:
         - method: "GET"
           path: "/metrics"
+  {{- if .Values.webhook.enabled }}
+  - toPorts:
+    - ports:
+      - port: "9443"
+        protocol: "TCP"
+  {{- end }}
 {{- end -}}

--- a/helm/silence-operator/templates/deployment.yaml
+++ b/helm/silence-operator/templates/deployment.yaml
@@ -88,7 +88,7 @@ spec:
         {{- if .Values.webhook.enabled }}
         - --webhook-cert-path=/certs
         {{- if .Values.webhook.mutating.enabled }}
-        - --webhook-cel-rules={{ .Values.webhook.celRules | toJson }}
+        - --webhook-cel-rules={{ .Values.webhook.mutating.celRules | toJson }}
         {{- end }}
         {{- if .Values.webhook.validating.enabled }}
         - --webhook-validating-enabled=true

--- a/helm/silence-operator/templates/deployment.yaml
+++ b/helm/silence-operator/templates/deployment.yaml
@@ -87,8 +87,12 @@ spec:
         {{- end }}
         {{- if .Values.webhook.enabled }}
         - --webhook-cert-path=/certs
+        {{- if .Values.webhook.mutating.enabled }}
         - --webhook-cel-rules={{ .Values.webhook.celRules | toJson }}
+        {{- end }}
+        {{- if .Values.webhook.validating.enabled }}
         - --webhook-validating-enabled=true
+        {{- end }}
         {{- end }}
         livenessProbe:
           {{- with .Values.livenessProbe }}

--- a/helm/silence-operator/templates/deployment.yaml
+++ b/helm/silence-operator/templates/deployment.yaml
@@ -88,6 +88,7 @@ spec:
         {{- if .Values.webhook.enabled }}
         - --webhook-cert-path=/certs
         - --webhook-cel-rules={{ .Values.webhook.celRules | toJson }}
+        - --webhook-validating-enabled=true
         {{- end }}
         livenessProbe:
           {{- with .Values.livenessProbe }}

--- a/helm/silence-operator/templates/mutatingwebhookconfiguration.yaml
+++ b/helm/silence-operator/templates/mutatingwebhookconfiguration.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.webhook.enabled }}
+{{- if and .Values.webhook.enabled .Values.webhook.mutating.enabled }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration

--- a/helm/silence-operator/templates/networkpolicy.yaml
+++ b/helm/silence-operator/templates/networkpolicy.yaml
@@ -15,6 +15,11 @@ spec:
   - ports:
     - port: http
       protocol: TCP
+  {{- if .Values.webhook.enabled }}
+  - ports:
+    - port: 9443
+      protocol: TCP
+  {{- end }}
   egress:
   - {}
   policyTypes:

--- a/helm/silence-operator/templates/validatingwebhookconfiguration.yaml
+++ b/helm/silence-operator/templates/validatingwebhookconfiguration.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.webhook.enabled }}
+{{- if and .Values.webhook.enabled .Values.webhook.validating.enabled }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/helm/silence-operator/templates/validatingwebhookconfiguration.yaml
+++ b/helm/silence-operator/templates/validatingwebhookconfiguration.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.webhook.enabled }}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+  name: {{ template "silence-operator.name" . }}
+  {{- if .Values.webhook.certManager.enabled }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ template "silence-operator.namespace" . }}/{{ template "silence-operator.name" . }}-webhook-cert
+  {{- end }}
+webhooks:
+- name: vsilence.observability.giantswarm.io
+  admissionReviewVersions: ["v1"]
+  failurePolicy: {{ .Values.webhook.failurePolicy | default "Fail" }}
+  sideEffects: None
+  clientConfig:
+    service:
+      name: {{ template "silence-operator.name" . }}-webhook
+      namespace: {{ template "silence-operator.namespace" . }}
+      path: /validate-observability-giantswarm-io-v1alpha2-silence
+    {{- if .Values.webhook.certManager.enabled }}
+    caBundle: Cg==
+    {{- else }}
+    caBundle: {{ required "webhook.caBundle is required when webhook.certManager.enabled is false (provide the base64-encoded PEM CA: kubectl get secret <tlsSecretName> -o jsonpath='{.data.ca\\.crt}')" .Values.webhook.caBundle }}
+    {{- end }}
+  rules:
+  - apiGroups:   ["observability.giantswarm.io"]
+    apiVersions: ["v1alpha2"]
+    operations:  ["CREATE", "UPDATE"]
+    resources:   ["silences"]
+{{- end }}

--- a/helm/silence-operator/values.schema.json
+++ b/helm/silence-operator/values.schema.json
@@ -217,12 +217,32 @@
         },
         "webhook": {
             "type": "object",
-            "description": "Mutating admission webhook for v1alpha2 Silences.",
+            "description": "Admission webhooks (mutating + validating) for v1alpha2 Silences.",
             "properties": {
                 "enabled": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Enable the mutating webhook."
+                    "description": "Master switch. Deploys TLS certificate, Service, and volume mount."
+                },
+                "mutating": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "default": true,
+                            "description": "Deploy the MutatingWebhookConfiguration and pass CEL rules to the operator."
+                        }
+                    }
+                },
+                "validating": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "default": true,
+                            "description": "Deploy the ValidatingWebhookConfiguration and enable the validation handler."
+                        }
+                    }
                 },
                 "celRules": {
                     "type": "array",

--- a/helm/silence-operator/values.schema.json
+++ b/helm/silence-operator/values.schema.json
@@ -231,6 +231,32 @@
                             "type": "boolean",
                             "default": true,
                             "description": "Deploy the MutatingWebhookConfiguration and pass CEL rules to the operator."
+                        },
+                        "celRules": {
+                            "type": "array",
+                            "description": "CEL-based mutation rules applied on CREATE/UPDATE. Empty condition = always apply.",
+                            "items": {
+                                "type": "object",
+                                "required": ["name"],
+                                "properties": {
+                                    "name": { "type": "string" },
+                                    "condition": { "type": "string", "default": "" },
+                                    "matchers": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "required": ["name", "value", "matchType"],
+                                            "properties": {
+                                                "name": { "type": "string" },
+                                                "value": { "type": "string" },
+                                                "matchType": { "type": "string", "enum": ["=", "!=", "=~", "!~"] }
+                                            }
+                                        }
+                                    },
+                                    "labels": { "type": "object", "additionalProperties": { "type": "string" } },
+                                    "annotations": { "type": "object", "additionalProperties": { "type": "string" } }
+                                }
+                            }
                         }
                     }
                 },
@@ -241,32 +267,6 @@
                             "type": "boolean",
                             "default": true,
                             "description": "Deploy the ValidatingWebhookConfiguration and enable the validation handler."
-                        }
-                    }
-                },
-                "celRules": {
-                    "type": "array",
-                    "description": "CEL-based mutation rules applied on CREATE/UPDATE. Empty condition = always apply.",
-                    "items": {
-                        "type": "object",
-                        "required": ["name"],
-                        "properties": {
-                            "name": { "type": "string" },
-                            "condition": { "type": "string", "default": "" },
-                            "matchers": {
-                                "type": "array",
-                                "items": {
-                                    "type": "object",
-                                    "required": ["name", "value", "matchType"],
-                                    "properties": {
-                                        "name": { "type": "string" },
-                                        "value": { "type": "string" },
-                                        "matchType": { "type": "string", "enum": ["=", "!=", "=~", "!~"] }
-                                    }
-                                }
-                            },
-                            "labels": { "type": "object", "additionalProperties": { "type": "string" } },
-                            "annotations": { "type": "object", "additionalProperties": { "type": "string" } }
                         }
                     }
                 },

--- a/helm/silence-operator/values.yaml
+++ b/helm/silence-operator/values.yaml
@@ -135,9 +135,15 @@ readinessProbe:
 # -- Restart policy for the pod (Always for single-instance reliability)
 restartPolicy: Always
 
-# Mutating webhook configuration.
-# The webhook applies CEL-based mutation rules to every v1alpha2 Silence on
+# Admission webhook configuration (mutating + validating).
+# When enabled, both webhooks are deployed and share the same TLS certificate and Service.
+#
+# The mutating webhook applies CEL-based mutation rules to every v1alpha2 Silence on
 # CREATE and UPDATE, replacing the Kyverno policy in kyverno-policies-observability.
+#
+# The validating webhook enforces business rules on CREATE and UPDATE:
+# duplicate matchers, invalid regex patterns, unparseable valid-until annotations,
+# and valid-until values already in the past (CREATE only).
 #
 # Rules with an empty condition always apply (unconditional injection).
 # Rules with a non-empty condition are evaluated as CEL expressions against the
@@ -170,7 +176,19 @@ restartPolicy: Always
 #     annotations:
 #       observability.giantswarm.io/reviewed: "true"
 webhook:
+  # Master switch. Deploys the TLS certificate, Service, and volume mount.
+  # Set to true to enable either or both webhook types below.
   enabled: false
+
+  # mutating controls the CEL-based mutation webhook.
+  # Requires celRules to be non-empty to have any effect.
+  mutating:
+    enabled: true
+
+  # validating controls the validation webhook (duplicate matchers, regex
+  # validity, valid-until annotation format and expiry).
+  validating:
+    enabled: true
 
   celRules: []
 

--- a/helm/silence-operator/values.yaml
+++ b/helm/silence-operator/values.yaml
@@ -138,61 +138,66 @@ restartPolicy: Always
 # Admission webhook configuration (mutating + validating).
 # When enabled, both webhooks are deployed and share the same TLS certificate and Service.
 #
-# The mutating webhook applies CEL-based mutation rules to every v1alpha2 Silence on
-# CREATE and UPDATE, replacing the Kyverno policy in kyverno-policies-observability.
-#
 # The validating webhook enforces business rules on CREATE and UPDATE:
 # duplicate matchers, invalid regex patterns, unparseable valid-until annotations,
 # and valid-until values already in the past (CREATE only).
-#
-# Rules with an empty condition always apply (unconditional injection).
-# Rules with a non-empty condition are evaluated as CEL expressions against the
-# incoming Silence resource, available as the `object` variable.
-# Supported mutations per rule: matchers, labels, annotations.
-#
-# To replicate the kyverno-policies-observability Silence policy:
-#
-#   celRules:
-#   - name: exclude-heartbeat
-#     condition: ""
-#     matchers:
-#     - name: alertname
-#       value: Heartbeat
-#       matchType: "!="
-#   - name: exclude-all-pipelines
-#     condition: ""
-#     matchers:
-#     - name: all_pipelines
-#       value: "true"
-#       matchType: "!="
-#
-# More examples:
-#   - name: tag-production-silences
-#     condition: 'object.metadata.namespace == "production"'
-#     labels:
-#       observability.giantswarm.io/env: production
-#   - name: require-team-label
-#     condition: '"team" in object.metadata.labels'
-#     annotations:
-#       observability.giantswarm.io/reviewed: "true"
 webhook:
   # Master switch. Deploys the TLS certificate, Service, and volume mount.
   # Set to true to enable either or both webhook types below.
   enabled: false
 
   # mutating controls the CEL-based mutation webhook.
-  # Requires celRules to be non-empty to have any effect.
   mutating:
     enabled: true
+
+    # celRules is a list of CEL-based mutation rules applied to every v1alpha2
+    # Silence on CREATE and UPDATE, replacing the Kyverno policy in
+    # kyverno-policies-observability.
+    #
+    # Each rule has:
+    #   name:      identifier (required)
+    #   condition: CEL expression evaluated against the incoming Silence as
+    #              `object`; empty string means always apply.
+    #              Use has() to safely access optional fields, e.g.:
+    #                has(object.metadata.labels) && "team" in object.metadata.labels
+    #   matchers:  list of {name, value, matchType} injected into spec.matchers
+    #              (idempotent — duplicates are never added).
+    #   labels:    key/value pairs merged into metadata.labels (last-write-wins).
+    #   annotations: key/value pairs merged into metadata.annotations.
+    #
+    # To replicate the kyverno-policies-observability Silence policy:
+    #
+    #   celRules:
+    #   - name: exclude-heartbeat
+    #     condition: ""
+    #     matchers:
+    #     - name: alertname
+    #       value: Heartbeat
+    #       matchType: "!="
+    #   - name: exclude-all-pipelines
+    #     condition: ""
+    #     matchers:
+    #     - name: all_pipelines
+    #       value: "true"
+    #       matchType: "!="
+    #
+    # Conditional examples:
+    #   - name: tag-production-silences
+    #     condition: 'object.metadata.namespace == "production"'
+    #     labels:
+    #       observability.giantswarm.io/env: production
+    #   - name: annotate-team-silences
+    #     condition: 'has(object.metadata.labels) && "team" in object.metadata.labels'
+    #     annotations:
+    #       observability.giantswarm.io/reviewed: "true"
+    celRules: []
 
   # validating controls the validation webhook (duplicate matchers, regex
   # validity, valid-until annotation format and expiry).
   validating:
     enabled: true
 
-  celRules: []
-
-  # failurePolicy controls what happens if the webhook is unreachable.
+  # failurePolicy controls what happens if either webhook is unreachable.
   # "Fail" (default) blocks the request; "Ignore" lets it through.
   failurePolicy: Fail
 


### PR DESCRIPTION
## Summary

Stacked on #660. Adds a validating webhook that enforces business rules the CRD OpenAPI schema cannot express.

**Validations:**
- **Duplicate matchers** — same name+value+matchType appearing more than once is rejected with the index of the duplicate
- **Regex validity** — `=~` and `!~` matchers must compile as valid Go regular expressions; bad patterns are caught at admission, not silently at sync time
- **`valid-until` parseability** — annotation must be RFC3339 or date-only (`YYYY-MM-DD`); bad format returns a clear error with accepted examples
- **Non-past expiry on CREATE** — creating an already-expired silence is rejected immediately; UPDATE allows past values so the controller can expire silences naturally