### PR TITLE
Skip CircleCI signing binary job on external PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ workflows:
         context: architect
         name: go-build
         binary: silence-operator
-        sign: << not pipeline.git.branch matches /^pull\/[0-9]+/ >>
+        sign: << not (pipeline.git.branch matches /^pull\/[0-9]+/) >>
         requires:
         - go-tests
         path: ./cmd

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,15 +72,13 @@ workflows:
         context: architect
         name: go-build
         binary: silence-operator
+        sign: << not pipeline.git.branch matches /^pull\/[0-9]+/ >>
         requires:
         - go-tests
         path: ./cmd
         filters:
           tags:
             only: /^v.*/
-          branches:
-            ignore:
-            - /pull\/[0-9]+/
 
     - architect/push-to-registries:
         context: architect

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,9 @@ workflows:
         filters:
           tags:
             only: /^v.*/
+          branches:
+            ignore:
+            - /pull\/[0-9]+/
 
     - architect/push-to-registries:
         context: architect


### PR DESCRIPTION
CI go-build job currently fails for PR submitted by external contributors.

This is due to the binary signing job requiring some internal secrets.
This PR fixes the issue by skipping the binary signing job for external
PRs.

This relies on the fact that external PR are named with `pull/<number`
while internal PR just use the actual branch name.

- External PR: https://app.circleci.com/pipelines/github/giantswarm/silence-operator/2386/workflows/d52ccaaf-2b6d-4348-80d8-7acea49fe4be/jobs/7713
<img width="591" height="90" alt="image" src="https://github.com/user-attachments/assets/7dcfcb6d-7260-4399-ae07-5ffccf5a28a8" />

- Internal PR: https://app.circleci.com/pipelines/github/giantswarm/silence-operator/2264/workflows/a268be97-eb8e-4b65-82d4-e1e30704479f/jobs/7184
<img width="572" height="95" alt="image" src="https://github.com/user-attachments/assets/9c452210-6434-41fb-91e8-c4a41a5f20c8" />


CircleCI project settings remain the same and no secrets are passed to external PR jobs.