### PR TITLE
build: Fix golangci lint errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Quote the `=` scalars in the generated `matchType` CRD schema so the rendered chart parses under PyYAML (unblocks the `HelmTemplateValidator` step added in app-build-suite 2.2.0).
 - Fix various CVEs by updating dependencies:
 - Skip failing CI jobs using private secrets for external contributions from fork
+- Replace deprecated controller-runtime scheme.Builder with apimachinery runtime.NewSchemeBuilder
+- Fix alertmanager_test.go linter errors
+
 
 ## [0.20.1] - 2026-02-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replace deprecated controller-runtime scheme.Builder with apimachinery runtime.NewSchemeBuilder
 - Fix `gosec`, `goconst` and `errcheck` linter errors in tests
 
-
 ## [0.20.1] - 2026-02-12
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix various CVEs by updating dependencies:
 - Skip failing CI jobs using private secrets for external contributions from fork
 - Replace deprecated controller-runtime scheme.Builder with apimachinery runtime.NewSchemeBuilder
-- Fix alertmanager_test.go linter errors
+- Fix `gosec`, `goconst` and `errcheck` linter errors in tests
 
 
 ## [0.20.1] - 2026-02-12

--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -20,8 +20,9 @@ limitations under the License.
 package v1alpha1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 var (
@@ -29,8 +30,17 @@ var (
 	GroupVersion = schema.GroupVersion{Group: "monitoring.giantswarm.io", Version: "v1alpha1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
-	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme
 )
+
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(GroupVersion,
+		&Silence{},
+	)
+
+	metav1.AddToGroupVersion(scheme, GroupVersion)
+	return nil
+}

--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -39,6 +39,7 @@ var (
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(GroupVersion,
 		&Silence{},
+		&SilenceList{},
 	)
 
 	metav1.AddToGroupVersion(scheme, GroupVersion)

--- a/api/v1alpha1/silence_types.go
+++ b/api/v1alpha1/silence_types.go
@@ -66,7 +66,3 @@ type SilenceList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Silence `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&Silence{}, &SilenceList{})
-}

--- a/api/v1alpha2/groupversion_info.go
+++ b/api/v1alpha2/groupversion_info.go
@@ -39,6 +39,7 @@ var (
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(GroupVersion,
 		&Silence{},
+		&SilenceList{},
 	)
 
 	metav1.AddToGroupVersion(scheme, GroupVersion)

--- a/api/v1alpha2/groupversion_info.go
+++ b/api/v1alpha2/groupversion_info.go
@@ -20,8 +20,9 @@ limitations under the License.
 package v1alpha2
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 var (
@@ -29,8 +30,17 @@ var (
 	GroupVersion = schema.GroupVersion{Group: "observability.giantswarm.io", Version: "v1alpha2"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme
 )
+
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(GroupVersion,
+		&Silence{},
+	)
+
+	metav1.AddToGroupVersion(scheme, GroupVersion)
+	return nil
+}

--- a/api/v1alpha2/silence_types.go
+++ b/api/v1alpha2/silence_types.go
@@ -78,7 +78,3 @@ type SilenceList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Silence `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&Silence{}, &SilenceList{})
-}

--- a/internal/controller/silence_controller_test.go
+++ b/internal/controller/silence_controller_test.go
@@ -79,7 +79,7 @@ var _ = Describe("Silence Controller", func() {
 		const resourceName = "test-silence-new"
 		typeNamespacedName := types.NamespacedName{
 			Name:      resourceName,
-			Namespace: "default",
+			Namespace: defaultNamespace,
 		}
 
 		BeforeEach(func() {
@@ -87,13 +87,13 @@ var _ = Describe("Silence Controller", func() {
 			resource := &monitoringv1alpha1.Silence{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      resourceName,
-					Namespace: "default",
+					Namespace: defaultNamespace,
 				},
 				Spec: monitoringv1alpha1.SilenceSpec{
 					Matchers: []monitoringv1alpha1.Matcher{
 						{
-							Name:    "alertname",
-							Value:   "TestAlert",
+							Name:    testMatcherName,
+							Value:   testMatcherValue,
 							IsRegex: false,
 						},
 						{
@@ -102,8 +102,8 @@ var _ = Describe("Silence Controller", func() {
 							IsRegex: false,
 						},
 					},
-					Owner:    "test-owner",
-					IssueURL: "https://github.com/example/test-issue",
+					Owner:    testOwner,
+					IssueURL: testIssueURL,
 				},
 			}
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
@@ -144,7 +144,7 @@ var _ = Describe("Silence Controller", func() {
 		const resourceName = "test-silence-existing"
 		typeNamespacedName := types.NamespacedName{
 			Name:      resourceName,
-			Namespace: "default",
+			Namespace: defaultNamespace,
 		}
 
 		BeforeEach(func() {
@@ -152,18 +152,18 @@ var _ = Describe("Silence Controller", func() {
 			resource := &monitoringv1alpha1.Silence{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      resourceName,
-					Namespace: "default",
+					Namespace: defaultNamespace,
 				},
 				Spec: monitoringv1alpha1.SilenceSpec{
 					Matchers: []monitoringv1alpha1.Matcher{
 						{
-							Name:    "alertname",
-							Value:   "TestAlert",
+							Name:    testMatcherName,
+							Value:   testMatcherValue,
 							IsRegex: false,
 						},
 					},
-					Owner:    "test-owner",
-					IssueURL: "https://github.com/example/test-issue",
+					Owner:    testOwner,
+					IssueURL: testIssueURL,
 				},
 			}
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
@@ -203,7 +203,7 @@ var _ = Describe("Silence Controller", func() {
 		const resourceName = "test-silence-legacy"
 		typeNamespacedName := types.NamespacedName{
 			Name:      resourceName,
-			Namespace: "default",
+			Namespace: defaultNamespace,
 		}
 
 		BeforeEach(func() {
@@ -211,19 +211,19 @@ var _ = Describe("Silence Controller", func() {
 			resource := &monitoringv1alpha1.Silence{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       resourceName,
-					Namespace:  "default",
+					Namespace:  defaultNamespace,
 					Finalizers: []string{legacySilenceFinalizer},
 				},
 				Spec: monitoringv1alpha1.SilenceSpec{
 					Matchers: []monitoringv1alpha1.Matcher{
 						{
-							Name:    "alertname",
-							Value:   "TestAlert",
+							Name:    testMatcherName,
+							Value:   testMatcherValue,
 							IsRegex: false,
 						},
 					},
-					Owner:    "test-owner",
-					IssueURL: "https://github.com/example/test-issue",
+					Owner:    testOwner,
+					IssueURL: testIssueURL,
 				},
 			}
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
@@ -258,7 +258,7 @@ var _ = Describe("Silence Controller", func() {
 		const resourceName = "test-silence-delete"
 		typeNamespacedName := types.NamespacedName{
 			Name:      resourceName,
-			Namespace: "default",
+			Namespace: defaultNamespace,
 		}
 
 		BeforeEach(func() {
@@ -266,18 +266,18 @@ var _ = Describe("Silence Controller", func() {
 			resource := &monitoringv1alpha1.Silence{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      resourceName,
-					Namespace: "default",
+					Namespace: defaultNamespace,
 				},
 				Spec: monitoringv1alpha1.SilenceSpec{
 					Matchers: []monitoringv1alpha1.Matcher{
 						{
-							Name:    "alertname",
-							Value:   "TestAlert",
+							Name:    testMatcherName,
+							Value:   testMatcherValue,
 							IsRegex: false,
 						},
 					},
-					Owner:    "test-owner",
-					IssueURL: "https://github.com/example/test-issue",
+					Owner:    testOwner,
+					IssueURL: testIssueURL,
 				},
 			}
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
@@ -314,7 +314,7 @@ var _ = Describe("Silence Controller", func() {
 		const resourceName = "test-silence-delete-legacy"
 		typeNamespacedName := types.NamespacedName{
 			Name:      resourceName,
-			Namespace: "default",
+			Namespace: defaultNamespace,
 		}
 
 		It("should handle deletion with legacy finalizer properly", func() {
@@ -322,19 +322,19 @@ var _ = Describe("Silence Controller", func() {
 			resource := &monitoringv1alpha1.Silence{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       resourceName,
-					Namespace:  "default",
+					Namespace:  defaultNamespace,
 					Finalizers: []string{silenceFinalizer, legacySilenceFinalizer},
 				},
 				Spec: monitoringv1alpha1.SilenceSpec{
 					Matchers: []monitoringv1alpha1.Matcher{
 						{
-							Name:    "alertname",
-							Value:   "TestAlert",
+							Name:    testMatcherName,
+							Value:   testMatcherValue,
 							IsRegex: false,
 						},
 					},
-					Owner:    "test-owner",
-					IssueURL: "https://github.com/example/test-issue",
+					Owner:    testOwner,
+					IssueURL: testIssueURL,
 				},
 			}
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
@@ -360,7 +360,7 @@ var _ = Describe("Silence Controller", func() {
 		const resourceName = "test-silence-invalid-date"
 		typeNamespacedName := types.NamespacedName{
 			Name:      resourceName,
-			Namespace: "default",
+			Namespace: defaultNamespace,
 		}
 
 		BeforeEach(func() {
@@ -368,7 +368,7 @@ var _ = Describe("Silence Controller", func() {
 			resource := &monitoringv1alpha1.Silence{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      resourceName,
-					Namespace: "default",
+					Namespace: defaultNamespace,
 					Annotations: map[string]string{
 						alertmanager.ValidUntilAnnotationName: "invalid-date-format",
 					},
@@ -376,13 +376,13 @@ var _ = Describe("Silence Controller", func() {
 				Spec: monitoringv1alpha1.SilenceSpec{
 					Matchers: []monitoringv1alpha1.Matcher{
 						{
-							Name:    "alertname",
-							Value:   "TestAlert",
+							Name:    testMatcherName,
+							Value:   testMatcherValue,
 							IsRegex: false,
 						},
 					},
-					Owner:    "test-owner",
-					IssueURL: "https://github.com/example/test-issue",
+					Owner:    testOwner,
+					IssueURL: testIssueURL,
 				},
 			}
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
@@ -411,7 +411,7 @@ var _ = Describe("Silence Controller", func() {
 		const resourceName = "test-silence-rfc3339-date"
 		typeNamespacedName := types.NamespacedName{
 			Name:      resourceName,
-			Namespace: "default",
+			Namespace: defaultNamespace,
 		}
 
 		BeforeEach(func() {
@@ -420,7 +420,7 @@ var _ = Describe("Silence Controller", func() {
 			resource := &monitoringv1alpha1.Silence{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      resourceName,
-					Namespace: "default",
+					Namespace: defaultNamespace,
 					Annotations: map[string]string{
 						alertmanager.ValidUntilAnnotationName: futureTime,
 					},
@@ -428,13 +428,13 @@ var _ = Describe("Silence Controller", func() {
 				Spec: monitoringv1alpha1.SilenceSpec{
 					Matchers: []monitoringv1alpha1.Matcher{
 						{
-							Name:    "alertname",
-							Value:   "TestAlert",
+							Name:    testMatcherName,
+							Value:   testMatcherValue,
 							IsRegex: false,
 						},
 					},
-					Owner:    "test-owner",
-					IssueURL: "https://github.com/example/test-issue",
+					Owner:    testOwner,
+					IssueURL: testIssueURL,
 				},
 			}
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
@@ -468,7 +468,7 @@ var _ = Describe("Silence Controller", func() {
 		const resourceName = "test-silence-legacy-date"
 		typeNamespacedName := types.NamespacedName{
 			Name:      resourceName,
-			Namespace: "default",
+			Namespace: defaultNamespace,
 		}
 
 		BeforeEach(func() {
@@ -477,7 +477,7 @@ var _ = Describe("Silence Controller", func() {
 			resource := &monitoringv1alpha1.Silence{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      resourceName,
-					Namespace: "default",
+					Namespace: defaultNamespace,
 					Annotations: map[string]string{
 						alertmanager.ValidUntilAnnotationName: futureDate,
 					},
@@ -485,13 +485,13 @@ var _ = Describe("Silence Controller", func() {
 				Spec: monitoringv1alpha1.SilenceSpec{
 					Matchers: []monitoringv1alpha1.Matcher{
 						{
-							Name:    "alertname",
-							Value:   "TestAlert",
+							Name:    testMatcherName,
+							Value:   testMatcherValue,
 							IsRegex: false,
 						},
 					},
-					Owner:    "test-owner",
-					IssueURL: "https://github.com/example/test-issue",
+					Owner:    testOwner,
+					IssueURL: testIssueURL,
 				},
 			}
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
@@ -527,7 +527,7 @@ var _ = Describe("Silence Controller", func() {
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{
 					Name:      "non-existent-silence",
-					Namespace: "default",
+					Namespace: defaultNamespace,
 				},
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -542,14 +542,14 @@ var _ = Describe("Silence Controller", func() {
 			cr := &monitoringv1alpha1.Silence{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "test-silence",
-					Namespace:         "default",
+					Namespace:         defaultNamespace,
 					CreationTimestamp: metav1.NewTime(testTime),
 				},
 				Spec: monitoringv1alpha1.SilenceSpec{
 					Matchers: []monitoringv1alpha1.Matcher{
 						{
-							Name:    "alertname",
-							Value:   "TestAlert",
+							Name:    testMatcherName,
+							Value:   testMatcherValue,
 							IsRegex: true,
 							IsEqual: &[]bool{false}[0], // pointer to false
 						},
@@ -575,8 +575,8 @@ var _ = Describe("Silence Controller", func() {
 			Expect(silence.Matchers).To(HaveLen(2))
 
 			// First matcher: IsEqual=false, IsRegex=true
-			Expect(silence.Matchers[0].Name).To(Equal("alertname"))
-			Expect(silence.Matchers[0].Value).To(Equal("TestAlert"))
+			Expect(silence.Matchers[0].Name).To(Equal(testMatcherName))
+			Expect(silence.Matchers[0].Value).To(Equal(testMatcherValue))
 			Expect(silence.Matchers[0].IsRegex).To(BeTrue())
 			Expect(silence.Matchers[0].IsEqual).To(BeFalse())
 

--- a/internal/controller/silence_v2_controller_test.go
+++ b/internal/controller/silence_v2_controller_test.go
@@ -44,7 +44,7 @@ var _ = Describe("SilenceV2 Controller", func() {
 
 		typeNamespacedName := types.NamespacedName{
 			Name:      resourceName,
-			Namespace: "default",
+			Namespace: defaultNamespace,
 		}
 		silence := &observabilityv1alpha2.Silence{}
 
@@ -58,12 +58,12 @@ var _ = Describe("SilenceV2 Controller", func() {
 				resource := &observabilityv1alpha2.Silence{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      resourceName,
-						Namespace: "default",
+						Namespace: defaultNamespace,
 					},
 					Spec: observabilityv1alpha2.SilenceSpec{
 						Matchers: []observabilityv1alpha2.SilenceMatcher{
 							{
-								Name:  "alertname",
+								Name:  testMatcherName,
 								Value: "TestAlertV2",
 							},
 						},
@@ -116,19 +116,19 @@ var _ = Describe("SilenceV2 Controller", func() {
 			finalizerTestResourceName := "finalizer-test-resource"
 			finalizerTestNamespacedName := types.NamespacedName{
 				Name:      finalizerTestResourceName,
-				Namespace: "default",
+				Namespace: defaultNamespace,
 			}
 
 			By("Creating a separate resource for finalizer testing")
 			finalizerTestResource := &observabilityv1alpha2.Silence{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      finalizerTestResourceName,
-					Namespace: "default",
+					Namespace: defaultNamespace,
 				},
 				Spec: observabilityv1alpha2.SilenceSpec{
 					Matchers: []observabilityv1alpha2.SilenceMatcher{
 						{
-							Name:  "alertname",
+							Name:  testMatcherName,
 							Value: "FinalizerTestAlert",
 						},
 					},
@@ -202,13 +202,13 @@ var _ = Describe("SilenceV2 Controller", func() {
 				silence := &observabilityv1alpha2.Silence{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-silence",
-						Namespace: "default",
+						Namespace: defaultNamespace,
 					},
 					Spec: observabilityv1alpha2.SilenceSpec{
 						Matchers: []observabilityv1alpha2.SilenceMatcher{
 							{
-								Name:      "alertname",
-								Value:     "TestAlert",
+								Name:      testMatcherName,
+								Value:     testMatcherValue,
 								MatchType: tc.matchType,
 							},
 						},
@@ -224,8 +224,8 @@ var _ = Describe("SilenceV2 Controller", func() {
 					"IsRegex mismatch for %s", tc.description)
 				Expect(matcher.IsEqual).To(Equal(tc.expectedIsEqual),
 					"IsEqual mismatch for %s", tc.description)
-				Expect(matcher.Name).To(Equal("alertname"))
-				Expect(matcher.Value).To(Equal("TestAlert"))
+				Expect(matcher.Name).To(Equal(testMatcherName))
+				Expect(matcher.Value).To(Equal(testMatcherValue))
 			}
 		})
 
@@ -235,8 +235,8 @@ var _ = Describe("SilenceV2 Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-namespace",
 					Labels: map[string]string{
-						"environment": "production",
-						"team":        "platform",
+						testLabelEnvironment: testEnvProduction,
+						testLabelTeam:        testTeamPlatform,
 					},
 				},
 			}
@@ -253,8 +253,8 @@ var _ = Describe("SilenceV2 Controller", func() {
 
 			// Test can the namespace selector matches the test namespace labels
 			Expect(namespaceSelectorLabels.Matches(labels.Set{
-				"environment": "production",
-				"team":        "platform",
+				testLabelEnvironment: testEnvProduction,
+				testLabelTeam:        testTeamPlatform,
 			})).To(BeTrue())
 
 			// Test that the namespace selector doesn't match different labels
@@ -264,8 +264,8 @@ var _ = Describe("SilenceV2 Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(nonMatchingNamespaceSelectorLabels.Matches(labels.Set{
-				"environment": "production",
-				"team":        "platform",
+				testLabelEnvironment: testEnvProduction,
+				testLabelTeam:        testTeamPlatform,
 			})).To(BeFalse())
 
 			By("Testing that namespace selector logic works correctly")

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -49,6 +49,21 @@ var (
 	k8sClient client.Client
 )
 
+// Values shared by the tests in this package.
+const (
+	defaultNamespace = "default"
+
+	testMatcherName  = "alertname"
+	testMatcherValue = "TestAlert"
+	testOwner        = "test-owner"
+	testIssueURL     = "https://github.com/example/test-issue"
+
+	testLabelEnvironment = "environment"
+	testLabelTeam        = "team"
+	testEnvProduction    = "production"
+	testTeamPlatform     = "platform"
+)
+
 // getKubeBuilderAssets attempts to get KUBEBUILDER_ASSETS from environment
 // or find the binaries automatically. Returns empty string if neither is available.
 func getKubeBuilderAssets() string {

--- a/pkg/alertmanager/alertmanager_test.go
+++ b/pkg/alertmanager/alertmanager_test.go
@@ -204,7 +204,7 @@ func TestAlertmanager_ListSilences(t *testing.T) {
 				}
 			}
 		]`))
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}))
 	defer server.Close()
 
@@ -243,7 +243,7 @@ func TestAlertmanager_GetSilenceByComment(t *testing.T) {
 				}
 			}
 		]`))
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}))
 	defer server.Close()
 
@@ -428,7 +428,7 @@ func TestAlertmanager_DeleteSilenceByComment(t *testing.T) {
 					}
 				}
 			]`))
-			require.NoError(t, err)
+			assert.NoError(t, err)
 		} else {
 			// Second call - delete silence
 			assert.Equal(t, "/api/v2/silence/test-id", r.URL.Path)
@@ -459,7 +459,7 @@ func TestAlertmanager_WithAuthentication(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_, err := w.Write([]byte(`[]`))
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}))
 	defer server.Close()
 
@@ -485,7 +485,7 @@ func TestAlertmanager_WithTenantID(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_, err := w.Write([]byte(`[]`))
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}))
 	defer server.Close()
 
@@ -561,7 +561,7 @@ func TestAlertmanager_ListSilences_WithTenant(t *testing.T) {
 				}
 			}
 		]`))
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}))
 	defer server.Close()
 
@@ -599,7 +599,7 @@ func TestAlertmanager_GetSilenceByComment_WithTenant(t *testing.T) {
 				}
 			}
 		]`))
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}))
 	defer server.Close()
 
@@ -644,7 +644,7 @@ func TestAlertmanager_TenantPrecedence(t *testing.T) {
 		assert.Equal(t, "param-tenant", r.Header.Get("X-Scope-OrgID"))
 		w.WriteHeader(http.StatusOK)
 		_, err := w.Write([]byte(`[]`))
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}))
 	defer server.Close()
 
@@ -665,7 +665,7 @@ func TestAlertmanager_BackwardCompatibilityUsesInstanceTenant(t *testing.T) {
 		assert.Equal(t, "instance-tenant", r.Header.Get("X-Scope-OrgID"))
 		w.WriteHeader(http.StatusOK)
 		_, err := w.Write([]byte(`[]`))
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}))
 	defer server.Close()
 

--- a/pkg/alertmanager/alertmanager_test.go
+++ b/pkg/alertmanager/alertmanager_test.go
@@ -14,6 +14,15 @@ import (
 	"github.com/giantswarm/silence-operator/pkg/config"
 )
 
+// Values shared by the tests in this file.
+const (
+	testAddress = "http://localhost:9093"
+
+	testComment      = "test-comment"
+	testMatcherName  = "alertname"
+	testMatcherValue = "test-alert"
+)
+
 func TestNew(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -23,7 +32,7 @@ func TestNew(t *testing.T) {
 		{
 			name: "valid config",
 			config: config.Config{
-				Address:        "http://localhost:9093",
+				Address:        testAddress,
 				Authentication: false,
 				BearerToken:    "",
 				TenantId:       "",
@@ -33,7 +42,7 @@ func TestNew(t *testing.T) {
 		{
 			name: "valid config with auth",
 			config: config.Config{
-				Address:        "http://localhost:9093",
+				Address:        testAddress,
 				Authentication: true,
 				BearerToken:    "test-token",
 				TenantId:       "test-tenant",
@@ -299,14 +308,14 @@ func TestAlertmanager_CreateSilence(t *testing.T) {
 	require.NoError(t, err)
 
 	silence := &Silence{
-		Comment:   "test-comment",
+		Comment:   testComment,
 		CreatedBy: CreatedBy,
 		StartsAt:  time.Now(),
 		EndsAt:    time.Now().Add(time.Hour),
 		Matchers: []Matcher{
 			{
-				Name:    "alertname",
-				Value:   "test-alert",
+				Name:    testMatcherName,
+				Value:   testMatcherValue,
 				IsRegex: false,
 				IsEqual: true,
 			},
@@ -336,14 +345,14 @@ func TestAlertmanager_UpdateSilence(t *testing.T) {
 
 	silence := &Silence{
 		ID:        "test-id",
-		Comment:   "test-comment",
+		Comment:   testComment,
 		CreatedBy: CreatedBy,
 		StartsAt:  time.Now(),
 		EndsAt:    time.Now().Add(time.Hour),
 		Matchers: []Matcher{
 			{
-				Name:    "alertname",
-				Value:   "test-alert",
+				Name:    testMatcherName,
+				Value:   testMatcherValue,
 				IsRegex: false,
 				IsEqual: true,
 			},
@@ -356,13 +365,13 @@ func TestAlertmanager_UpdateSilence(t *testing.T) {
 
 func TestAlertmanager_UpdateSilence_MissingID(t *testing.T) {
 	config := config.Config{
-		Address: "http://localhost:9093",
+		Address: testAddress,
 	}
 	am, err := New(config)
 	require.NoError(t, err)
 
 	silence := &Silence{
-		Comment:   "test-comment",
+		Comment:   testComment,
 		CreatedBy: CreatedBy,
 		StartsAt:  time.Now(),
 		EndsAt:    time.Now().Add(time.Hour),
@@ -435,7 +444,7 @@ func TestAlertmanager_DeleteSilenceByComment(t *testing.T) {
 	am, err := New(config)
 	require.NoError(t, err)
 
-	err = am.DeleteSilenceByComment("test-comment", "")
+	err = am.DeleteSilenceByComment(testComment, "")
 	assert.NoError(t, err)
 	assert.Equal(t, 2, callCount) // Should have made both calls
 }
@@ -512,14 +521,14 @@ func TestAlertmanager_CreateSilence_WithTenant(t *testing.T) {
 	require.NoError(t, err)
 
 	silence := &Silence{
-		Comment:   "test-comment",
+		Comment:   testComment,
 		CreatedBy: CreatedBy,
 		StartsAt:  time.Now(),
 		EndsAt:    time.Now().Add(time.Hour),
 		Matchers: []Matcher{
 			{
-				Name:    "alertname",
-				Value:   "test-alert",
+				Name:    testMatcherName,
+				Value:   testMatcherValue,
 				IsRegex: false,
 				IsEqual: true,
 			},
@@ -634,7 +643,8 @@ func TestAlertmanager_TenantPrecedence(t *testing.T) {
 		// Should get the parameter tenant, not the instance tenant
 		assert.Equal(t, "param-tenant", r.Header.Get("X-Scope-OrgID"))
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`[]`)) // nolint:errcheck
+		_, err := w.Write([]byte(`[]`))
+		require.NoError(t, err)
 	}))
 	defer server.Close()
 
@@ -654,7 +664,8 @@ func TestAlertmanager_BackwardCompatibilityUsesInstanceTenant(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "instance-tenant", r.Header.Get("X-Scope-OrgID"))
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`[]`)) // nolint:errcheck
+		_, err := w.Write([]byte(`[]`))
+		require.NoError(t, err)
 	}))
 	defer server.Close()
 

--- a/pkg/alertmanager/alertmanager_test.go
+++ b/pkg/alertmanager/alertmanager_test.go
@@ -634,7 +634,7 @@ func TestAlertmanager_TenantPrecedence(t *testing.T) {
 		// Should get the parameter tenant, not the instance tenant
 		assert.Equal(t, "param-tenant", r.Header.Get("X-Scope-OrgID"))
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`[]`))
+		w.Write([]byte(`[]`)) // nolint:errcheck
 	}))
 	defer server.Close()
 
@@ -654,7 +654,7 @@ func TestAlertmanager_BackwardCompatibilityUsesInstanceTenant(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "instance-tenant", r.Header.Get("X-Scope-OrgID"))
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`[]`))
+		w.Write([]byte(`[]`)) // nolint:errcheck
 	}))
 	defer server.Close()
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -7,6 +7,9 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
+// testLabelEnvironment is the label key used by the selector tests in this file.
+const testLabelEnvironment = "environment"
+
 func TestParseSilenceSelector(t *testing.T) {
 	g := gomega.NewWithT(t)
 
@@ -57,16 +60,16 @@ func TestParseSilenceSelector(t *testing.T) {
 
 		// Test matching labels
 		matchingLabels := labels.Set{
-			"environment": "production",
-			"tier":        "frontend",
-			"app":         "some-app",
+			testLabelEnvironment: "production",
+			"tier":               "frontend",
+			"app":                "some-app",
 		}
 		g.Expect(selector.Matches(matchingLabels)).To(gomega.BeTrue())
 
 		// Test non-matching labels
 		nonMatchingLabels := labels.Set{
-			"environment": "staging", // Different value
-			"tier":        "frontend",
+			testLabelEnvironment: "staging", // Different value
+			"tier":               "frontend",
 		}
 		g.Expect(selector.Matches(nonMatchingLabels)).To(gomega.BeFalse())
 	})
@@ -122,16 +125,16 @@ func TestParseNamespaceSelector(t *testing.T) {
 
 		// Test matching namespace labels
 		matchingLabels := labels.Set{
-			"environment": "production",
-			"team":        "platform",
-			"managed-by":  "argocd",
+			testLabelEnvironment: "production",
+			"team":               "platform",
+			"managed-by":         "argocd",
 		}
 		g.Expect(selector.Matches(matchingLabels)).To(gomega.BeTrue())
 
 		// Test non-matching namespace labels
 		nonMatchingLabels := labels.Set{
-			"environment": "staging", // Different value
-			"team":        "platform",
+			testLabelEnvironment: "staging", // Different value
+			"team":               "platform",
 		}
 		g.Expect(selector.Matches(nonMatchingLabels)).To(gomega.BeFalse())
 	})


### PR DESCRIPTION
Since the new tooling upgrade that came with https://github.com/giantswarm/silence-operator/pull/701, golangci does run in CI and pointed our some issues.

- Replace deprecated controller-runtime scheme.Builder with apimachinery
   runtime.NewSchemeBuilder

   SA1019: scheme.Builder is deprecated: This helper is only useful in api
   packages, but api packages should be easy to import and hence have minimal
   dependencies. Typically, these dependencies include only the standard
   library, k8s.io/apimachinery and other api packages. (staticcheck)

- Fix alertmanager_test.go linter errors: Error return value of `w.Write` is
   not checked (errcheck)