### PR TITLE
build: Skip failing CI jobs using private secrets for external contri…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,7 @@ workflows:
           branches:
             ignore:
             - main
+            - /pull\/[0-9]+/
 
     - architect/push-to-app-catalog:
         context: architect
@@ -107,3 +108,4 @@ workflows:
           branches:
             ignore:
             - main
+            - /pull\/[0-9]+/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Quote the `=` scalars in the generated `matchType` CRD schema so the rendered chart parses under PyYAML (unblocks the `HelmTemplateValidator` step added in app-build-suite 2.2.0).
 - Fix various CVEs by updating dependencies:
+- Skip failing CI jobs using private secrets for external contributions from fork
 
 ## [0.20.1] - 2026-02-12
 


### PR DESCRIPTION
Following on: https://github.com/giantswarm/silence-operator/pull/700

More CI jobs are failing for external contributions via forks, see https://github.com/giantswarm/silence-operator/pull/703

https://app.circleci.com/pipelines/github/giantswarm/silence-operator/2396/details?workflowId=c1162514-f44a-41be-811b-75b489524893&job=9839eeb7-1876-4461-be71-4850890d6290&buildNumber=7758&jobType=build#step-109-


CI job `push-to-registries` is failing with:

```
Using registries data from the circle.ci environment settings.
Environment variable REGISTRIES_DATA_BASE64 is not set properly in circleci's context.
```

We should skip this and the following `push-to-catalog` as those rely on private secrets.