### PR TITLE
build: Remove duplicated Makefile targets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
     - checkout
     - run:
         name: Run unit and integration tests
-        command: CGO_ENABLED=0 make test
+        command: CGO_ENABLED=0 make test-ginkgo
 
   e2e-tests:
     machine:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ Thank you for your interest in contributing to the silence-operator! This guide 
 4. **Update documentation** as needed
 5. **Test your changes**:
    ```bash
-   make test
+   make test-ginkgo
    make lint
    ```
 6. **Bump the chart version** for every change (see `helm/silence-operator/Chart.yaml`)

--- a/Makefile.kubebuilder.mk
+++ b/Makefile.kubebuilder.mk
@@ -158,24 +158,6 @@ manifests-legacy: generate-manifests
 # Code Quality and Development Tools
 # ==================================================================================
 
-.PHONY: fmt
-fmt: ## Run go fmt against code
-	$(call log_build,"Running go fmt")
-	@go fmt ./...
-	@$(call log_info,"Code formatting completed")
-
-.PHONY: vet
-vet: ## Run go vet against code
-	$(call log_build,"Running go vet")
-	@go vet ./...
-	@$(call log_info,"Code vetting completed")
-
-.PHONY: lint
-lint: golangci-lint ## Run golangci-lint linter
-	$(call log_build,"Running golangci-lint")
-	@$(GOLANGCI_LINT) run -E gosec -E goconst --timeout=15m ./...
-	@$(call log_info,"Linting completed")
-
 .PHONY: lint-fix
 lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
 	$(call log_build,"Running golangci-lint with auto-fix")
@@ -193,7 +175,7 @@ lint-config: golangci-lint ## Verify golangci-lint linter configuration
 # ==================================================================================
 
 .PHONY: test
-test: ginkgo envtest ## Run tests with Ginkgo and envtest
+test-ginkgo: ginkgo envtest ## Run tests with Ginkgo and envtest
 	$(call log_build,"Running tests with Ginkgo")
 	@KUBEBUILDER_ASSETS="$$($(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" \
 		$(GINKGO) -p --nodes 4 -randomize-all --randomize-suites --cover --skip-package=e2e ./...

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -67,7 +67,7 @@ This installs:
 
 ```bash
 # Run all tests
-make test
+make test-ginkgo
 
 # Run tests with specific Ginkgo arguments (modify test target as needed)
 $(GINKGO) -focus='Silence Controller' ./...
@@ -95,7 +95,7 @@ bin/ginkgo -focus='Controller' ./...
 bin/ginkgo -skip='Integration' ./...
 
 # Set Kubernetes version for envtest
-make test ENVTEST_K8S_VERSION="1.29"
+make test-ginkgo ENVTEST_K8S_VERSION="1.29"
 
 # Run tests with verbose output
 bin/ginkgo -v ./...
@@ -314,7 +314,7 @@ The test target automatically generates coverage information with Ginkgo:
 
 ```bash
 # Run tests (includes coverage)
-make test
+make test-ginkgo
 
 # Generate HTML coverage report
 go tool cover -html=coverprofile.out -o coverage.html
@@ -326,7 +326,7 @@ go tool cover -func=coverprofile.out
 ### Coverage Output
 
 Coverage reports are saved to:
-- `coverprofile.out` - Default coverage profile from Ginkgo via make test
+- `coverprofile.out` - Default coverage profile from Ginkgo via make test-ginkgo
 - `coverage.html` - HTML visualization (if generated manually)
 
 ## Debugging Tests
@@ -353,7 +353,7 @@ bin/golangci-lint version
 bin/setup-envtest list
 
 # Verify KUBEBUILDER_ASSETS detection
-make test ENVTEST_K8S_VERSION="1.30"
+make test-ginkgo ENVTEST_K8S_VERSION="1.30"
 ```
 
 # Verify tools are installed
@@ -377,7 +377,7 @@ make install-tools
 3. **Test Timeouts**
    ```bash
    # Solution: Increase timeout with Ginkgo args
-   make test GINKGO_ARGS="-timeout=15m"
+   make test-ginkgo GINKGO_ARGS="-timeout=15m"
    ```
 
 ## Continuous Integration
@@ -472,7 +472,7 @@ Tests must pass the following quality gates:
 kubectl get crd --context=envtest
 
 # Check controller logs in tests
-make test GINKGO_ARGS="-v" 2>&1 | grep "controller"
+make test-ginkgo GINKGO_ARGS="-v" 2>&1 | grep "controller"
 ```
 
 For more specific troubleshooting, refer to the individual test files and the Kubebuilder documentation.


### PR DESCRIPTION
With PR #701, some Makefile targets are now duplicated since there is now a Makefile.gen.go.mk which takes care of `make fmt/lint/vet`.

I've renamed our `make test` to `make test-ginkgo`, since there is a new `make test` (which run `go test` under the hood), which conficlts with our previous `make test` target which runs `ginkgo`. I took care of replacing all instance of our `make test` in docs, ci, etc.
