### PR TITLE
fix(helm): Disable helm release revision deployment annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.1] - 2026-09-02
+
+### Fixed
+
+- [Helm] Fixed noisy Helm diffs caused by .Release.Revision changing on every upgrade. The release revision provides no meaningful value in the rendered manifest, as Helm already tracks release revisions in its release metadata.
+
 ## [0.21.0] - 2026-08-18
 
 ### Added

--- a/helm/silence-operator/Chart.yaml
+++ b/helm/silence-operator/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
-appVersion: 0.21.0
+appVersion: 0.21.1
 description: The silence-operator manages alertmanager silences.
 home: https://github.com/giantswarm/silence-operator
 icon: https://s.giantswarm.io/app-icons/giantswarm/1/light.svg
 name: silence-operator
-version: 0.21.0
+version: 0.21.1
 annotations:
   io.giantswarm.application.team: "atlas"

--- a/helm/silence-operator/templates/deployment.yaml
+++ b/helm/silence-operator/templates/deployment.yaml
@@ -19,8 +19,6 @@ spec:
     metadata:
       labels:
         {{- include "labels.common" . | nindent 8 }}
-      annotations:
-        releaseRevision: {{ .Release.Revision | quote }}
     spec:
       {{- if or .Values.affinity .Values.nodeAffinity }}
       affinity:


### PR DESCRIPTION
## [0.21.1] - 2026-09-02

### Fixed

- [Helm] Fixed noisy Helm diffs caused by .Release.Revision changing on every upgrade. The release revision provides no meaningful value in the rendered manifest, as Helm already tracks release revisions in its release metadata.
